### PR TITLE
feat: MCP agent for AI-powered Magic gameplay

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
   ],
-  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  ignorePatterns: ['dist', '.eslintrc.cjs', 'maginet-agent'],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh', 'eslint-plugin-react-compiler'],
   rules: {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,5 +15,9 @@ module.exports = {
       { allowConstantExport: true },
     ],
     'react-compiler/react-compiler': 'error',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    ],
   },
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "maginet": {
+      "command": "node",
+      "args": ["./maginet-agent/dist/index.js", "--port", "3210", "--visibility", "full"]
+    }
+  }
+}

--- a/docs/superpowers/plans/2026-03-28-maginet-agent.md
+++ b/docs/superpowers/plans/2026-03-28-maginet-agent.md
@@ -1,0 +1,2308 @@
+# Maginet Agent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an MCP server that lets Claude Code play or advise on Magic: The Gathering games running in a live Maginet browser tab, connected via WebSocket.
+
+**Architecture:** A Node.js MCP server (`maginet-agent/`) communicates with Claude Code over stdio and with the browser over WebSocket. The browser gets a new `WebSocketTransport` implementing the existing `SyncTransport` interface from `@vescofire/peersync`. The agent joins as a sync peer — shapes and card actions flow through the same diff/patch/snapshot model used by PeerJS. In opponent mode the agent holds its own deck/hand state; in copilot mode it reads the browser's state.
+
+**Tech Stack:** Node.js, TypeScript, `ws` (WebSocket), `@modelcontextprotocol/sdk`, `@vescofire/peersync`, Scryfall REST API, Vitest
+
+---
+
+## File Map
+
+### New files — `maginet-agent/` package
+
+| File | Responsibility |
+|------|---------------|
+| `maginet-agent/package.json` | Package manifest — deps: `ws`, `@modelcontextprotocol/sdk`, `@vescofire/peersync` |
+| `maginet-agent/tsconfig.json` | TypeScript config — Node ESM, imports from shared `src/` |
+| `maginet-agent/src/index.ts` | CLI entry — parses `--port` and `--visibility` args, wires server + MCP |
+| `maginet-agent/src/server.ts` | WebSocket server + `SyncTransport` implementation for Node side |
+| `maginet-agent/src/state.ts` | Agent game state — wraps `cardReducer`, tracks agent's shapes |
+| `maginet-agent/src/visibility.ts` | Filters game state based on `fair` / `full` visibility setting |
+| `maginet-agent/src/mcp.ts` | MCP tool definitions and handlers |
+| `maginet-agent/src/scryfall.ts` | Scryfall API client for deck loading (Node `fetch`) |
+| `maginet-agent/src/__tests__/state.test.ts` | Unit tests for agent state |
+| `maginet-agent/src/__tests__/visibility.test.ts` | Unit tests for visibility filter |
+| `maginet-agent/src/__tests__/server.integration.test.ts` | Integration test — WS transport + sync |
+| `maginet-agent/src/__tests__/mcp.test.ts` | MCP tool handler tests |
+
+### New files — browser side
+
+| File | Responsibility |
+|------|---------------|
+| `src/sync/transport/websocket.ts` | `SyncTransport` implementation using browser `WebSocket` |
+| `src/sync/transport/websocket.test.ts` | Unit tests for WS transport |
+
+### Modified files — browser side
+
+| File | Change |
+|------|--------|
+| `src/sync/react/peerStore.ts` | Add optional WebSocket transport alongside PeerJS |
+| `src/board/components/SetupScreen.tsx` | "Connect Agent" button on multiplayer step |
+
+---
+
+## Task 1: Scaffold `maginet-agent` package
+
+**Files:**
+- Create: `maginet-agent/package.json`
+- Create: `maginet-agent/tsconfig.json`
+
+- [ ] **Step 1: Create package.json**
+
+```json
+{
+  "name": "maginet-agent",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.5.10",
+    "typescript": "^5.2.2",
+    "vitest": "^4.0.18"
+  }
+}
+```
+
+- [ ] **Step 2: Create tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 3: Install dependencies**
+
+Run: `cd maginet-agent && pnpm install`
+Expected: Dependencies installed, `node_modules/` created.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add maginet-agent/package.json maginet-agent/tsconfig.json maginet-agent/pnpm-lock.yaml
+git commit -m "chore: scaffold maginet-agent package"
+```
+
+---
+
+## Task 2: Agent game state (`state.ts`)
+
+Wraps the existing `cardReducer` to manage the agent's deck and hand. Also tracks which shapes on the board belong to the agent.
+
+**Files:**
+- Create: `maginet-agent/src/state.ts`
+- Create: `maginet-agent/src/__tests__/state.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// maginet-agent/src/__tests__/state.test.ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { AgentGameState } from "../state.js";
+
+const makeCard = (id: string, src = [`https://example.com/${id}.png`]) => ({
+  id,
+  src,
+});
+
+describe("AgentGameState", () => {
+  let state: AgentGameState;
+
+  beforeEach(() => {
+    state = new AgentGameState();
+  });
+
+  it("initializes with empty deck and hand", () => {
+    expect(state.getHand()).toEqual([]);
+    expect(state.getDeckSize()).toBe(0);
+  });
+
+  it("initializes a deck", () => {
+    const cards = [makeCard("a"), makeCard("b"), makeCard("c")];
+    state.initializeDeck(cards);
+    expect(state.getDeckSize()).toBe(3);
+    expect(state.getHand()).toEqual([]);
+  });
+
+  it("draws a card from deck to hand", () => {
+    state.initializeDeck([makeCard("a"), makeCard("b")]);
+    const drawn = state.drawCard();
+    expect(drawn).toBeDefined();
+    expect(state.getHand()).toHaveLength(1);
+    expect(state.getDeckSize()).toBe(1);
+  });
+
+  it("returns null when drawing from empty deck", () => {
+    const drawn = state.drawCard();
+    expect(drawn).toBeNull();
+  });
+
+  it("mulligans hand back into deck", () => {
+    state.initializeDeck([makeCard("a"), makeCard("b"), makeCard("c")]);
+    state.drawCard();
+    state.drawCard();
+    expect(state.getHand()).toHaveLength(2);
+    state.mulligan();
+    expect(state.getHand()).toHaveLength(0);
+    expect(state.getDeckSize()).toBe(3);
+  });
+
+  it("plays a card from hand and returns it", () => {
+    state.initializeDeck([makeCard("a")]);
+    state.drawCard();
+    const hand = state.getHand();
+    const cardId = hand[0].id;
+    const played = state.playCard(cardId);
+    expect(played).toBeDefined();
+    expect(played!.src).toEqual(["https://example.com/a.png"]);
+    expect(state.getHand()).toHaveLength(0);
+  });
+
+  it("returns null when playing a card not in hand", () => {
+    const played = state.playCard("nonexistent");
+    expect(played).toBeNull();
+  });
+
+  it("sends a card back to hand", () => {
+    const card = makeCard("returned");
+    state.sendToHand([card]);
+    expect(state.getHand()).toHaveLength(1);
+    expect(state.getHand()[0].src).toEqual(card.src);
+  });
+
+  it("sends a card to deck top", () => {
+    state.initializeDeck([makeCard("a")]);
+    state.sendToDeck([makeCard("top")], "top");
+    expect(state.getDeckSize()).toBe(2);
+    // Draw should get the card we put on top
+    const drawn = state.drawCard();
+    expect(drawn!.src).toEqual(["https://example.com/top.png"]);
+  });
+
+  it("sends a card to deck bottom", () => {
+    state.initializeDeck([makeCard("a")]);
+    state.sendToDeck([makeCard("bottom")], "bottom");
+    expect(state.getDeckSize()).toBe(2);
+    // Draw should get original top card, not the bottom one
+    const drawn = state.drawCard();
+    expect(drawn!.src).toEqual(["https://example.com/a.png"]);
+  });
+
+  it("shuffles the deck", () => {
+    const cards = Array.from({ length: 20 }, (_, i) => makeCard(`card-${i}`));
+    state.initializeDeck(cards);
+    const before = state.getDeckContents().map((c) => c.id);
+    state.shuffleDeck();
+    const after = state.getDeckContents().map((c) => c.id);
+    // Extremely unlikely to be identical after shuffle of 20 cards
+    expect(after).not.toEqual(before);
+  });
+
+  it("tracks agent shapes", () => {
+    expect(state.getAgentShapes()).toEqual([]);
+    const shape = {
+      id: "s1",
+      point: [100, 200],
+      size: [100, 100],
+      type: "image" as const,
+      srcIndex: 0,
+      src: ["https://example.com/card.png"],
+    };
+    state.addAgentShape(shape);
+    expect(state.getAgentShapes()).toHaveLength(1);
+    state.removeAgentShape("s1");
+    expect(state.getAgentShapes()).toEqual([]);
+  });
+
+  it("updates an agent shape", () => {
+    const shape = {
+      id: "s1",
+      point: [100, 200],
+      size: [100, 100],
+      type: "image" as const,
+      srcIndex: 0,
+    };
+    state.addAgentShape(shape);
+    state.updateAgentShape("s1", { rotation: 90 });
+    expect(state.getAgentShapes()[0].rotation).toBe(90);
+  });
+
+  it("exposes cardState for sync", () => {
+    state.initializeDeck([makeCard("a")]);
+    const cardState = state.getCardState();
+    expect(cardState.deck).toHaveLength(1);
+    expect(cardState.cards).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd maginet-agent && pnpm test`
+Expected: FAIL — `AgentGameState` not found.
+
+- [ ] **Step 3: Implement AgentGameState**
+
+```typescript
+// maginet-agent/src/state.ts
+import type { Shape } from "../../src/types/canvas.js";
+
+export interface Card {
+  id: string;
+  src: string[];
+}
+
+export interface CardState {
+  cards: Card[];
+  deck: Card[];
+  lastAction?: string;
+  actionId?: number;
+}
+
+function generateId(): string {
+  return Math.random().toString(36).substr(2, 9);
+}
+
+function shuffle<T>(array: T[]): T[] {
+  return array
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}
+
+export class AgentGameState {
+  private cardState: CardState = { cards: [], deck: [], actionId: 0 };
+  private agentShapes: Shape[] = [];
+  private shapeListeners = new Set<(next: Shape[], prev: Shape[]) => void>();
+
+  getHand(): Card[] {
+    return this.cardState.cards;
+  }
+
+  getDeckSize(): number {
+    return this.cardState.deck.length;
+  }
+
+  getDeckContents(): Card[] {
+    return this.cardState.deck;
+  }
+
+  getCardState(): CardState {
+    return this.cardState;
+  }
+
+  getAgentShapes(): Shape[] {
+    return this.agentShapes;
+  }
+
+  subscribeShapes(listener: (next: Shape[], prev: Shape[]) => void): () => void {
+    this.shapeListeners.add(listener);
+    return () => { this.shapeListeners.delete(listener); };
+  }
+
+  private notifyShapeChange(prev: Shape[]) {
+    this.shapeListeners.forEach((listener) => listener(this.agentShapes, prev));
+  }
+
+  private nextAction(action: string): void {
+    this.cardState = {
+      ...this.cardState,
+      lastAction: action,
+      actionId: (this.cardState.actionId ?? 0) + 1,
+    };
+  }
+
+  initializeDeck(cards: Card[]): void {
+    this.nextAction("INITIALIZE_DECK");
+    this.cardState = {
+      ...this.cardState,
+      deck: cards.map((c) => ({ ...c })),
+      cards: [],
+    };
+  }
+
+  drawCard(): Card | null {
+    if (this.cardState.deck.length === 0) return null;
+    this.nextAction("DRAW_CARD");
+    const [drawn, ...rest] = this.cardState.deck;
+    const drawnCard = { ...drawn, id: generateId() };
+    this.cardState = {
+      ...this.cardState,
+      deck: rest,
+      cards: [...this.cardState.cards, drawnCard],
+    };
+    return drawnCard;
+  }
+
+  mulligan(): void {
+    this.nextAction("MULLIGAN");
+    this.cardState = {
+      ...this.cardState,
+      deck: [...this.cardState.deck, ...this.cardState.cards],
+      cards: [],
+    };
+  }
+
+  playCard(cardId: string): Card | null {
+    const card = this.cardState.cards.find((c) => c.id === cardId);
+    if (!card) return null;
+    this.nextAction("PLAY_CARD");
+    this.cardState = {
+      ...this.cardState,
+      cards: this.cardState.cards.filter((c) => c.id !== cardId),
+    };
+    return card;
+  }
+
+  sendToHand(cards: Card[]): void {
+    this.nextAction("SEND_TO_HAND");
+    this.cardState = {
+      ...this.cardState,
+      cards: [...this.cardState.cards, ...cards],
+    };
+  }
+
+  sendToDeck(cards: Card[], position: "top" | "bottom"): void {
+    this.nextAction("SEND_TO_DECK");
+    this.cardState = {
+      ...this.cardState,
+      deck:
+        position === "top"
+          ? [...cards, ...this.cardState.deck]
+          : [...this.cardState.deck, ...cards],
+    };
+  }
+
+  shuffleDeck(): void {
+    this.nextAction("SHUFFLE_DECK");
+    this.cardState = {
+      ...this.cardState,
+      deck: shuffle(this.cardState.deck),
+    };
+  }
+
+  addAgentShape(shape: Shape): void {
+    const prev = this.agentShapes;
+    this.agentShapes = [...this.agentShapes, shape];
+    this.notifyShapeChange(prev);
+  }
+
+  removeAgentShape(shapeId: string): void {
+    const prev = this.agentShapes;
+    this.agentShapes = this.agentShapes.filter((s) => s.id !== shapeId);
+    this.notifyShapeChange(prev);
+  }
+
+  updateAgentShape(shapeId: string, updates: Partial<Shape>): void {
+    const prev = this.agentShapes;
+    this.agentShapes = this.agentShapes.map((s) =>
+      s.id === shapeId ? { ...s, ...updates } : s
+    );
+    this.notifyShapeChange(prev);
+  }
+
+  findAgentShape(shapeId: string): Shape | undefined {
+    return this.agentShapes.find((s) => s.id === shapeId);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd maginet-agent && pnpm test`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add maginet-agent/src/state.ts maginet-agent/src/__tests__/state.test.ts
+git commit -m "feat(agent): add AgentGameState for deck/hand/shape management"
+```
+
+---
+
+## Task 3: Visibility filter (`visibility.ts`)
+
+Filters game state based on the `fair` or `full` visibility setting.
+
+**Files:**
+- Create: `maginet-agent/src/visibility.ts`
+- Create: `maginet-agent/src/__tests__/visibility.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// maginet-agent/src/__tests__/visibility.test.ts
+import { describe, it, expect } from "vitest";
+import { filterGameState, type RawGameState, type VisibleGameState } from "../visibility.js";
+
+const makeCard = (id: string) => ({ id, src: [`https://example.com/${id}.png`] });
+const makeShape = (id: string) => ({
+  id,
+  point: [0, 0],
+  size: [100, 100],
+  type: "image" as const,
+  srcIndex: 0,
+  src: [`https://example.com/${id}.png`],
+});
+
+const rawState: RawGameState = {
+  agentHand: [makeCard("a1"), makeCard("a2")],
+  agentDeck: [makeCard("d1"), makeCard("d2"), makeCard("d3")],
+  boardShapes: { agent: [makeShape("s1")], opponent: [makeShape("s2")] },
+  opponentHand: [makeCard("o1"), makeCard("o2"), makeCard("o3")],
+  opponentDeckSize: 10,
+};
+
+describe("filterGameState", () => {
+  it("fair: shows agent hand, hides deck contents, hides opponent hand", () => {
+    const result = filterGameState(rawState, "fair");
+    expect(result.agentHand).toEqual(rawState.agentHand);
+    expect(result.agentDeckSize).toBe(3);
+    expect(result.agentDeckContents).toBeUndefined();
+    expect(result.opponentHandCount).toBe(3);
+    expect(result.opponentHandContents).toBeUndefined();
+    expect(result.boardShapes).toEqual(rawState.boardShapes);
+  });
+
+  it("full: shows everything including deck contents and opponent hand", () => {
+    const result = filterGameState(rawState, "full");
+    expect(result.agentHand).toEqual(rawState.agentHand);
+    expect(result.agentDeckSize).toBe(3);
+    expect(result.agentDeckContents).toEqual(rawState.agentDeck);
+    expect(result.opponentHandCount).toBe(3);
+    expect(result.opponentHandContents).toEqual(rawState.opponentHand);
+  });
+
+  it("board shapes are always fully visible", () => {
+    const fair = filterGameState(rawState, "fair");
+    const full = filterGameState(rawState, "full");
+    expect(fair.boardShapes).toEqual(full.boardShapes);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd maginet-agent && pnpm test`
+Expected: FAIL — `filterGameState` not found.
+
+- [ ] **Step 3: Implement visibility filter**
+
+```typescript
+// maginet-agent/src/visibility.ts
+import type { Shape } from "../../src/types/canvas.js";
+
+export type Visibility = "fair" | "full";
+
+export interface Card {
+  id: string;
+  src: string[];
+}
+
+export interface RawGameState {
+  agentHand: Card[];
+  agentDeck: Card[];
+  boardShapes: Record<string, Shape[]>;
+  opponentHand: Card[];
+  opponentDeckSize: number;
+}
+
+export interface VisibleGameState {
+  agentHand: Card[];
+  agentDeckSize: number;
+  agentDeckContents?: Card[];
+  boardShapes: Record<string, Shape[]>;
+  opponentHandCount: number;
+  opponentHandContents?: Card[];
+  opponentDeckSize: number;
+}
+
+export function filterGameState(
+  raw: RawGameState,
+  visibility: Visibility
+): VisibleGameState {
+  const base: VisibleGameState = {
+    agentHand: raw.agentHand,
+    agentDeckSize: raw.agentDeck.length,
+    boardShapes: raw.boardShapes,
+    opponentHandCount: raw.opponentHand.length,
+    opponentDeckSize: raw.opponentDeckSize,
+  };
+
+  if (visibility === "full") {
+    base.agentDeckContents = raw.agentDeck;
+    base.opponentHandContents = raw.opponentHand;
+  }
+
+  return base;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd maginet-agent && pnpm test`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add maginet-agent/src/visibility.ts maginet-agent/src/__tests__/visibility.test.ts
+git commit -m "feat(agent): add visibility filter for fair/full game state"
+```
+
+---
+
+## Task 4: Scryfall client (`scryfall.ts`)
+
+Fetches card data from the Scryfall API for deck loading. Mirrors the logic in `src/hooks/useCards.ts` but runs in Node.
+
+**Files:**
+- Create: `maginet-agent/src/scryfall.ts`
+
+- [ ] **Step 1: Implement Scryfall client**
+
+```typescript
+// maginet-agent/src/scryfall.ts
+
+interface ScryfallImageUris {
+  normal: string;
+  [key: string]: string;
+}
+
+interface ScryfallCardFace {
+  image_uris: ScryfallImageUris;
+}
+
+interface ScryfallCard {
+  image_uris?: ScryfallImageUris;
+  card_faces?: ScryfallCardFace[];
+  name: string;
+}
+
+interface ScryfallCollection {
+  data: ScryfallCard[];
+  not_found: Array<{ name: string }>;
+}
+
+export interface DeckCard {
+  id: string;
+  src: string[];
+}
+
+function generateId(): string {
+  return Math.random().toString(36).substr(2, 9);
+}
+
+function shuffle<T>(array: T[]): T[] {
+  return array
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}
+
+export function parseDeckList(deckList: string): string[] {
+  if (deckList.trim() === "") return [];
+  return deckList.split("\n").flatMap((line) => {
+    const match = line.match(/^(\d+)\s+(.*?)(?:\s*\/\/.*)?$/);
+    if (match) {
+      const [, count, name] = match;
+      return Array(Number(count)).fill(name.trim());
+    }
+    return [];
+  });
+}
+
+async function fetchCards(names: string[]): Promise<ScryfallCollection> {
+  const response = await fetch("https://api.scryfall.com/cards/collection", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      identifiers: names.map((name) => ({ name })),
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Scryfall API error: ${response.status} ${await response.text()}`);
+  }
+  return response.json() as Promise<ScryfallCollection>;
+}
+
+function scryfallCardToDeckCard(card: ScryfallCard): DeckCard {
+  if (card.image_uris?.normal) {
+    return { id: generateId(), src: [card.image_uris.normal] };
+  }
+  if (card.card_faces?.length) {
+    return {
+      id: generateId(),
+      src: card.card_faces.map((face) => face.image_uris.normal),
+    };
+  }
+  throw new Error(`No image found for card: ${card.name}`);
+}
+
+export async function loadDeckFromList(deckList: string): Promise<DeckCard[]> {
+  const names = parseDeckList(deckList);
+  if (names.length === 0) throw new Error("Empty deck list");
+  if (names.length > 200) throw new Error("Deck list too large (max 200 cards)");
+
+  // Batch in chunks of 75 (Scryfall limit)
+  const chunks: string[][] = [];
+  const remaining = [...names];
+  while (remaining.length > 0) {
+    chunks.push(remaining.splice(0, 75));
+  }
+
+  const collections = await Promise.all(chunks.map(fetchCards));
+
+  const notFound = collections.flatMap((c) => c.not_found.map((nf) => nf.name));
+  if (notFound.length > 0) {
+    console.warn(`Cards not found: ${notFound.join(", ")}`);
+  }
+
+  const cards = collections.flatMap((c) => c.data.map(scryfallCardToDeckCard));
+  return shuffle(cards);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add maginet-agent/src/scryfall.ts
+git commit -m "feat(agent): add Scryfall API client for deck loading"
+```
+
+---
+
+## Task 5: WebSocket transport — Node server side (`server.ts`)
+
+The MCP server's WebSocket server that implements `SyncTransport` to participate in the sync engine as a peer.
+
+**Files:**
+- Create: `maginet-agent/src/server.ts`
+- Create: `maginet-agent/src/__tests__/server.integration.test.ts`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```typescript
+// maginet-agent/src/__tests__/server.integration.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { AgentWebSocketServer } from "../server.js";
+
+const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const waitFor = async (
+  assertion: () => void,
+  timeoutMs = 2000,
+  pollMs = 10
+) => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try { assertion(); return; }
+    catch { await wait(pollMs); }
+  }
+  assertion();
+};
+
+describe("AgentWebSocketServer", () => {
+  let server: AgentWebSocketServer | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+  });
+
+  it("starts and accepts a WebSocket connection", async () => {
+    server = new AgentWebSocketServer({ port: 0 }); // random port
+    const port = await server.start();
+
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+
+    await waitFor(() => {
+      expect(server!.isConnected()).toBe(true);
+    });
+
+    ws.close();
+  });
+
+  it("receives messages from browser client", async () => {
+    server = new AgentWebSocketServer({ port: 0 });
+    const port = await server.start();
+
+    const received: unknown[] = [];
+    server.onMessage((msg) => received.push(msg));
+
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+
+    ws.send(JSON.stringify({ type: "test", payload: { value: 42 } }));
+
+    await waitFor(() => {
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual({ type: "test", payload: { value: 42 } });
+    });
+
+    ws.close();
+  });
+
+  it("sends messages to browser client", async () => {
+    server = new AgentWebSocketServer({ port: 0 });
+    const port = await server.start();
+
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+
+    const received: unknown[] = [];
+    ws.on("message", (data) => received.push(JSON.parse(data.toString())));
+
+    server.send({ type: "hello", payload: { from: "agent" } });
+
+    await waitFor(() => {
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual({ type: "hello", payload: { from: "agent" } });
+    });
+
+    ws.close();
+  });
+
+  it("detects disconnection", async () => {
+    server = new AgentWebSocketServer({ port: 0 });
+    const port = await server.start();
+
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+
+    await waitFor(() => expect(server!.isConnected()).toBe(true));
+
+    ws.close();
+
+    await waitFor(() => expect(server!.isConnected()).toBe(false));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd maginet-agent && pnpm test`
+Expected: FAIL — `AgentWebSocketServer` not found.
+
+- [ ] **Step 3: Implement AgentWebSocketServer**
+
+```typescript
+// maginet-agent/src/server.ts
+import { WebSocketServer, WebSocket } from "ws";
+import type { SyncEnvelope } from "@vescofire/peersync";
+
+export interface AgentWebSocketServerOptions {
+  port: number;
+}
+
+type MessageListener = (message: SyncEnvelope) => void;
+type ConnectionListener = (peerId: string) => void;
+
+export class AgentWebSocketServer {
+  private wss: WebSocketServer | null = null;
+  private client: WebSocket | null = null;
+  private port: number;
+  private messageListeners = new Set<MessageListener>();
+  private connectListeners = new Set<ConnectionListener>();
+  private disconnectListeners = new Set<ConnectionListener>();
+  private browserPeerId = "browser";
+
+  constructor(options: AgentWebSocketServerOptions) {
+    this.port = options.port;
+  }
+
+  async start(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.wss = new WebSocketServer({ port: this.port }, () => {
+        const address = this.wss!.address();
+        const assignedPort = typeof address === "object" ? address.port : this.port;
+        resolve(assignedPort);
+      });
+
+      this.wss.on("error", reject);
+
+      this.wss.on("connection", (ws) => {
+        this.client = ws;
+        this.connectListeners.forEach((listener) => listener(this.browserPeerId));
+
+        ws.on("message", (data) => {
+          try {
+            const message = JSON.parse(data.toString()) as SyncEnvelope;
+            this.messageListeners.forEach((listener) => listener(message));
+          } catch {
+            // Ignore malformed messages
+          }
+        });
+
+        ws.on("close", () => {
+          this.client = null;
+          this.disconnectListeners.forEach((listener) => listener(this.browserPeerId));
+        });
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.client) {
+      this.client.close();
+      this.client = null;
+    }
+    return new Promise((resolve) => {
+      if (!this.wss) { resolve(); return; }
+      this.wss.close(() => {
+        this.wss = null;
+        resolve();
+      });
+    });
+  }
+
+  isConnected(): boolean {
+    return this.client !== null && this.client.readyState === WebSocket.OPEN;
+  }
+
+  send(message: SyncEnvelope): void {
+    if (!this.client || this.client.readyState !== WebSocket.OPEN) return;
+    this.client.send(JSON.stringify(message));
+  }
+
+  onMessage(listener: MessageListener): () => void {
+    this.messageListeners.add(listener);
+    return () => { this.messageListeners.delete(listener); };
+  }
+
+  onConnect(listener: ConnectionListener): () => void {
+    this.connectListeners.add(listener);
+    return () => { this.connectListeners.delete(listener); };
+  }
+
+  onDisconnect(listener: ConnectionListener): () => void {
+    this.disconnectListeners.add(listener);
+    return () => { this.disconnectListeners.delete(listener); };
+  }
+
+  getBrowserPeerId(): string {
+    return this.browserPeerId;
+  }
+
+  setBrowserPeerId(peerId: string): void {
+    this.browserPeerId = peerId;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd maginet-agent && pnpm test`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add maginet-agent/src/server.ts maginet-agent/src/__tests__/server.integration.test.ts
+git commit -m "feat(agent): add WebSocket server with message passing"
+```
+
+---
+
+## Task 6: MCP tool definitions (`mcp.ts`)
+
+Defines all MCP tools and their handlers, wiring them to `AgentGameState` and `AgentWebSocketServer`.
+
+**Files:**
+- Create: `maginet-agent/src/mcp.ts`
+- Create: `maginet-agent/src/__tests__/mcp.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// maginet-agent/src/__tests__/mcp.test.ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { createToolHandlers, type ToolContext } from "../mcp.js";
+import { AgentGameState } from "../state.js";
+
+const makeCard = (id: string) => ({ id, src: [`https://example.com/${id}.png`] });
+
+// Minimal mock for server
+const mockServer = () => {
+  const sent: unknown[] = [];
+  return {
+    send: (msg: unknown) => { sent.push(msg); },
+    isConnected: () => true,
+    getSent: () => sent,
+  };
+};
+
+describe("MCP tool handlers", () => {
+  let state: AgentGameState;
+  let server: ReturnType<typeof mockServer>;
+  let handlers: ReturnType<typeof createToolHandlers>;
+
+  beforeEach(() => {
+    state = new AgentGameState();
+    server = mockServer();
+    handlers = createToolHandlers({
+      state,
+      server: server as any,
+      visibility: "full",
+      remoteShapes: {},
+      remoteCardState: null,
+    });
+  });
+
+  it("getHand returns empty hand initially", async () => {
+    const result = await handlers.getHand({});
+    expect(result.content[0].text).toContain("[]");
+  });
+
+  it("drawCard draws a card and returns it", async () => {
+    state.initializeDeck([makeCard("bolt")]);
+    const result = await handlers.drawCard({});
+    expect(result.content[0].text).toContain("bolt");
+    expect(state.getHand()).toHaveLength(1);
+  });
+
+  it("drawCard fails on empty deck", async () => {
+    const result = await handlers.drawCard({});
+    expect(result.isError).toBe(true);
+  });
+
+  it("playCard plays a card from hand", async () => {
+    state.initializeDeck([makeCard("bolt")]);
+    state.drawCard();
+    const cardId = state.getHand()[0].id;
+    const result = await handlers.playCard({ cardId });
+    expect(result.isError).toBeUndefined();
+    expect(state.getHand()).toHaveLength(0);
+    expect(state.getAgentShapes()).toHaveLength(1);
+  });
+
+  it("playCard fails when card not in hand", async () => {
+    const result = await handlers.playCard({ cardId: "nope" });
+    expect(result.isError).toBe(true);
+  });
+
+  it("tapCard toggles rotation on agent shape", async () => {
+    state.initializeDeck([makeCard("bolt")]);
+    state.drawCard();
+    const cardId = state.getHand()[0].id;
+    await handlers.playCard({ cardId });
+    const shapeId = state.getAgentShapes()[0].id;
+
+    await handlers.tapCard({ shapeId });
+    expect(state.getAgentShapes()[0].rotation).toBe(90);
+
+    await handlers.tapCard({ shapeId });
+    expect(state.getAgentShapes()[0].rotation).toBe(0);
+  });
+
+  it("getGameState respects full visibility", async () => {
+    state.initializeDeck([makeCard("a"), makeCard("b")]);
+    state.drawCard();
+
+    const result = await handlers.getGameState({});
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.agentDeckContents).toBeDefined();
+    expect(parsed.agentDeckContents).toHaveLength(1);
+  });
+
+  it("getGameState respects fair visibility", async () => {
+    state.initializeDeck([makeCard("a"), makeCard("b")]);
+    state.drawCard();
+
+    const fairHandlers = createToolHandlers({
+      state,
+      server: server as any,
+      visibility: "fair",
+      remoteShapes: {},
+      remoteCardState: null,
+    });
+
+    const result = await fairHandlers.getGameState({});
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.agentDeckContents).toBeUndefined();
+  });
+
+  it("mulligan shuffles hand back to deck", async () => {
+    state.initializeDeck([makeCard("a"), makeCard("b"), makeCard("c")]);
+    state.drawCard();
+    state.drawCard();
+    expect(state.getHand()).toHaveLength(2);
+
+    await handlers.mulligan({});
+    expect(state.getHand()).toHaveLength(0);
+    expect(state.getDeckSize()).toBe(3);
+  });
+
+  it("getBoardState returns shapes", async () => {
+    const boardHandlers = createToolHandlers({
+      state,
+      server: server as any,
+      visibility: "full",
+      remoteShapes: {
+        "browser-peer": [
+          { id: "s1", point: [0, 0], size: [100, 100], type: "image", srcIndex: 0 },
+        ],
+      },
+      remoteCardState: null,
+    });
+
+    const result = await boardHandlers.getBoardState({});
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed["browser-peer"]).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd maginet-agent && pnpm test`
+Expected: FAIL — `createToolHandlers` not found.
+
+- [ ] **Step 3: Implement MCP tool handlers**
+
+```typescript
+// maginet-agent/src/mcp.ts
+import type { AgentGameState } from "./state.js";
+import type { AgentWebSocketServer } from "./server.js";
+import type { Visibility } from "./visibility.js";
+import { filterGameState } from "./visibility.js";
+import type { Shape, Counter } from "../../src/types/canvas.js";
+
+function generateId(): string {
+  return Math.random().toString(36).substr(2, 9);
+}
+
+type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+function ok(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+}
+
+function err(message: string): ToolResult {
+  return { content: [{ type: "text", text: message }], isError: true };
+}
+
+export interface ToolContext {
+  state: AgentGameState;
+  server: AgentWebSocketServer;
+  visibility: Visibility;
+  remoteShapes: Record<string, Shape[]>;
+  remoteCardState: { cards: number; deck: number } | null;
+}
+
+export function createToolHandlers(ctx: ToolContext) {
+  return {
+    getGameState: async (_args: Record<string, unknown>) => {
+      const raw = {
+        agentHand: ctx.state.getHand(),
+        agentDeck: ctx.state.getDeckContents(),
+        boardShapes: {
+          agent: ctx.state.getAgentShapes(),
+          ...ctx.remoteShapes,
+        },
+        opponentHand: [] as { id: string; src: string[] }[], // populated from sync
+        opponentDeckSize: ctx.remoteCardState?.deck ?? 0,
+      };
+      return ok(filterGameState(raw, ctx.visibility));
+    },
+
+    getHand: async (_args: Record<string, unknown>) => {
+      return ok(ctx.state.getHand());
+    },
+
+    getBoardState: async (_args: Record<string, unknown>) => {
+      return ok({
+        agent: ctx.state.getAgentShapes(),
+        ...ctx.remoteShapes,
+      });
+    },
+
+    getDeckInfo: async (_args: Record<string, unknown>) => {
+      const info: Record<string, unknown> = {
+        size: ctx.state.getDeckSize(),
+      };
+      if (ctx.visibility === "full") {
+        info.contents = ctx.state.getDeckContents();
+      }
+      return ok(info);
+    },
+
+    drawCard: async (_args: Record<string, unknown>) => {
+      const card = ctx.state.drawCard();
+      if (!card) return err("Deck is empty — cannot draw.");
+      return ok(card);
+    },
+
+    mulligan: async (_args: Record<string, unknown>) => {
+      ctx.state.mulligan();
+      return ok({ success: true, deckSize: ctx.state.getDeckSize() });
+    },
+
+    playCard: async (args: Record<string, unknown>) => {
+      const cardId = args.cardId as string;
+      if (!cardId) return err("cardId is required.");
+
+      const card = ctx.state.playCard(cardId);
+      if (!card) return err(`Card ${cardId} not found in hand.`);
+
+      const position = (args.position as [number, number]) ?? [
+        200 + Math.random() * 400,
+        200 + Math.random() * 200,
+      ];
+      const faceDown = (args.faceDown as boolean) ?? false;
+
+      const shape: Shape = {
+        id: generateId(),
+        point: position,
+        size: [100, 100],
+        type: "image",
+        src: card.src,
+        srcIndex: 0,
+        rotation: 0,
+        isFlipped: faceDown,
+      };
+
+      ctx.state.addAgentShape(shape);
+      return ok({ shape, card });
+    },
+
+    tapCard: async (args: Record<string, unknown>) => {
+      const shapeId = args.shapeId as string;
+      if (!shapeId) return err("shapeId is required.");
+
+      const shape = ctx.state.findAgentShape(shapeId);
+      if (!shape) return err(`Shape ${shapeId} not found.`);
+
+      const newRotation = (shape.rotation || 0) === 90 ? 0 : 90;
+      ctx.state.updateAgentShape(shapeId, { rotation: newRotation });
+      return ok({ shapeId, rotation: newRotation });
+    },
+
+    untapAll: async (_args: Record<string, unknown>) => {
+      const shapes = ctx.state.getAgentShapes();
+      let count = 0;
+      for (const shape of shapes) {
+        if (shape.rotation) {
+          ctx.state.updateAgentShape(shape.id, { rotation: 0 });
+          count++;
+        }
+      }
+      return ok({ untapped: count });
+    },
+
+    sendToHand: async (args: Record<string, unknown>) => {
+      const shapeId = args.shapeId as string;
+      if (!shapeId) return err("shapeId is required.");
+
+      const shape = ctx.state.findAgentShape(shapeId);
+      if (!shape) return err(`Shape ${shapeId} not found.`);
+      if (shape.type !== "image" || !shape.src) return err("Shape is not a card.");
+
+      ctx.state.removeAgentShape(shapeId);
+      ctx.state.sendToHand([{ id: generateId(), src: shape.src }]);
+      return ok({ success: true, handSize: ctx.state.getHand().length });
+    },
+
+    sendToDeck: async (args: Record<string, unknown>) => {
+      const shapeId = args.shapeId as string;
+      const position = (args.position as "top" | "bottom") ?? "top";
+      if (!shapeId) return err("shapeId is required.");
+
+      const shape = ctx.state.findAgentShape(shapeId);
+      if (!shape) return err(`Shape ${shapeId} not found.`);
+      if (shape.type !== "image" || !shape.src) return err("Shape is not a card.");
+
+      ctx.state.removeAgentShape(shapeId);
+      ctx.state.sendToDeck([{ id: generateId(), src: shape.src }], position);
+      return ok({ success: true, deckSize: ctx.state.getDeckSize() });
+    },
+
+    shuffleDeck: async (_args: Record<string, unknown>) => {
+      ctx.state.shuffleDeck();
+      return ok({ success: true, deckSize: ctx.state.getDeckSize() });
+    },
+
+    addCounter: async (args: Record<string, unknown>) => {
+      const shapeId = args.shapeId as string;
+      const counter = args.counter as Counter;
+      if (!shapeId || !counter) return err("shapeId and counter are required.");
+
+      const shape = ctx.state.findAgentShape(shapeId);
+      if (!shape) return err(`Shape ${shapeId} not found.`);
+
+      const counters = [...(shape.counters || [])];
+      const existingIdx = counters.findIndex((c) => c.label === counter.label);
+      if (existingIdx >= 0) {
+        counters[existingIdx] = counter;
+      } else {
+        counters.push(counter);
+      }
+      ctx.state.updateAgentShape(shapeId, { counters });
+      return ok({ shapeId, counters });
+    },
+
+    removeCounter: async (args: Record<string, unknown>) => {
+      const shapeId = args.shapeId as string;
+      const label = args.label as string;
+      if (!shapeId || !label) return err("shapeId and label are required.");
+
+      const shape = ctx.state.findAgentShape(shapeId);
+      if (!shape) return err(`Shape ${shapeId} not found.`);
+
+      const counters = (shape.counters || []).filter((c) => c.label !== label);
+      ctx.state.updateAgentShape(shapeId, { counters });
+      return ok({ shapeId, counters });
+    },
+
+    flipCard: async (args: Record<string, unknown>) => {
+      const shapeId = args.shapeId as string;
+      if (!shapeId) return err("shapeId is required.");
+
+      const shape = ctx.state.findAgentShape(shapeId);
+      if (!shape) return err(`Shape ${shapeId} not found.`);
+
+      ctx.state.updateAgentShape(shapeId, { isFlipped: !shape.isFlipped });
+      return ok({ shapeId, isFlipped: !shape.isFlipped });
+    },
+
+    transformCard: async (args: Record<string, unknown>) => {
+      const shapeId = args.shapeId as string;
+      if (!shapeId) return err("shapeId is required.");
+
+      const shape = ctx.state.findAgentShape(shapeId);
+      if (!shape) return err(`Shape ${shapeId} not found.`);
+
+      const nextIndex = (shape.srcIndex + 1) % (shape.src?.length ?? 1);
+      ctx.state.updateAgentShape(shapeId, { srcIndex: nextIndex });
+      return ok({ shapeId, srcIndex: nextIndex });
+    },
+  };
+}
+
+export const TOOL_DEFINITIONS = [
+  {
+    name: "getGameState",
+    description: "Get a full snapshot of the current game: your hand, deck size, board shapes, and opponent info. Visibility settings control what is visible.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "getHand",
+    description: "Get the cards currently in your hand.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "getBoardState",
+    description: "Get all shapes on the board, grouped by player. Shows positions, tap state, counters, z-order.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "getDeckInfo",
+    description: "Get deck size. In full visibility mode, also returns deck contents.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "loadDeck",
+    description: "Load a deck from a deck list string (MTGO/MTGA format, e.g. '4 Lightning Bolt\\n20 Mountain'). Fetches card images from Scryfall.",
+    inputSchema: {
+      type: "object" as const,
+      properties: { deckList: { type: "string", description: "Deck list in MTGO format" } },
+      required: ["deckList"],
+    },
+  },
+  {
+    name: "loadSnapshot",
+    description: "Load a debug snapshot JSON to resume a game state. The snapshot must match the format from Maginet's debug export.",
+    inputSchema: {
+      type: "object" as const,
+      properties: { snapshot: { type: "string", description: "JSON string of a Maginet debug snapshot" } },
+      required: ["snapshot"],
+    },
+  },
+  {
+    name: "drawCard",
+    description: "Draw the top card from your deck into your hand.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "mulligan",
+    description: "Shuffle your entire hand back into your deck.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "playCard",
+    description: "Play a card from your hand onto the board.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        cardId: { type: "string", description: "ID of the card in hand to play" },
+        position: {
+          type: "array",
+          items: { type: "number" },
+          description: "Optional [x, y] position on the board. Defaults to a random position.",
+        },
+        faceDown: { type: "boolean", description: "Play the card face down. Defaults to false." },
+      },
+      required: ["cardId"],
+    },
+  },
+  {
+    name: "tapCard",
+    description: "Toggle tap/untap on a card (rotate 0 to 90 degrees, or 90 to 0). In MTG, tapped cards are sideways.",
+    inputSchema: {
+      type: "object" as const,
+      properties: { shapeId: { type: "string", description: "ID of the shape on the board" } },
+      required: ["shapeId"],
+    },
+  },
+  {
+    name: "untapAll",
+    description: "Untap all your cards on the board (set rotation to 0). Typically done at the start of your turn.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "sendToHand",
+    description: "Return a card from the board back to your hand.",
+    inputSchema: {
+      type: "object" as const,
+      properties: { shapeId: { type: "string", description: "ID of the shape to return" } },
+      required: ["shapeId"],
+    },
+  },
+  {
+    name: "sendToDeck",
+    description: "Return a card from the board to your deck.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        shapeId: { type: "string", description: "ID of the shape to return" },
+        position: { type: "string", enum: ["top", "bottom"], description: "Where to place the card in the deck" },
+      },
+      required: ["shapeId"],
+    },
+  },
+  {
+    name: "shuffleDeck",
+    description: "Shuffle your deck.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "addCounter",
+    description: "Add or update a counter on a card (e.g. +1/+1, loyalty, charge).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        shapeId: { type: "string", description: "ID of the shape" },
+        counter: {
+          type: "object",
+          description: "Counter object with label, optional power/toughness or value, optional color",
+          properties: {
+            label: { type: "string" },
+            power: { type: "number" },
+            toughness: { type: "number" },
+            value: { type: "number" },
+            color: { type: "string" },
+          },
+          required: ["label"],
+        },
+      },
+      required: ["shapeId", "counter"],
+    },
+  },
+  {
+    name: "removeCounter",
+    description: "Remove a counter from a card by its label.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        shapeId: { type: "string", description: "ID of the shape" },
+        label: { type: "string", description: "Label of the counter to remove" },
+      },
+      required: ["shapeId", "label"],
+    },
+  },
+  {
+    name: "flipCard",
+    description: "Toggle a card between face-up and face-down.",
+    inputSchema: {
+      type: "object" as const,
+      properties: { shapeId: { type: "string", description: "ID of the shape" } },
+      required: ["shapeId"],
+    },
+  },
+  {
+    name: "transformCard",
+    description: "Switch a double-faced card to its other face.",
+    inputSchema: {
+      type: "object" as const,
+      properties: { shapeId: { type: "string", description: "ID of the shape" } },
+      required: ["shapeId"],
+    },
+  },
+];
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd maginet-agent && pnpm test`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add maginet-agent/src/mcp.ts maginet-agent/src/__tests__/mcp.test.ts
+git commit -m "feat(agent): add MCP tool definitions and handlers"
+```
+
+---
+
+## Task 7: CLI entry point (`index.ts`)
+
+Wires the MCP server, WebSocket server, game state, and sync engine together. Parses CLI args and starts everything.
+
+**Files:**
+- Create: `maginet-agent/src/index.ts`
+
+- [ ] **Step 1: Implement entry point**
+
+```typescript
+// maginet-agent/src/index.ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { AgentWebSocketServer } from "./server.js";
+import { AgentGameState } from "./state.js";
+import { createToolHandlers, TOOL_DEFINITIONS, type ToolContext } from "./mcp.js";
+import { loadDeckFromList } from "./scryfall.js";
+import type { Visibility } from "./visibility.js";
+import type { Shape } from "../../src/types/canvas.js";
+
+function parseArgs(argv: string[]): { port: number; visibility: Visibility } {
+  let port = 3210;
+  let visibility: Visibility = "fair";
+
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--port" && argv[i + 1]) {
+      port = parseInt(argv[i + 1], 10);
+    }
+    if (argv[i] === "--visibility" && argv[i + 1]) {
+      visibility = argv[i + 1] as Visibility;
+    }
+  }
+
+  return { port, visibility };
+}
+
+async function main() {
+  const { port, visibility } = parseArgs(process.argv.slice(2));
+
+  const gameState = new AgentGameState();
+  const wsServer = new AgentWebSocketServer({ port });
+  const remoteShapes: Record<string, Shape[]> = {};
+  let remoteCardState: { cards: number; deck: number } | null = null;
+
+  const assignedPort = await wsServer.start();
+  console.error(`[maginet-agent] WebSocket server listening on port ${assignedPort}`);
+  console.error(`[maginet-agent] Visibility: ${visibility}`);
+
+  // Listen for sync messages from browser
+  wsServer.onMessage((message) => {
+    if (message.type === "sync:channel-snapshot" || message.type === "sync:channel-patch") {
+      // Handle shape sync from browser
+      const payload = message.payload as Record<string, unknown>;
+      if (payload && typeof payload === "object") {
+        // Store remote shapes keyed by peer ID
+        for (const [peerId, shapes] of Object.entries(payload)) {
+          if (Array.isArray(shapes)) {
+            remoteShapes[peerId] = shapes as Shape[];
+          }
+        }
+      }
+    }
+
+    if (message.type === "action-log") {
+      const payload = message.payload as Record<string, unknown>;
+      console.error(`[maginet-agent] Action: ${JSON.stringify(payload)}`);
+    }
+
+    if (message.type === "card-state-sync") {
+      const payload = message.payload as { cards: number; deck: number };
+      remoteCardState = payload;
+    }
+  });
+
+  // Create MCP server
+  const mcp = new McpServer({
+    name: "maginet-agent",
+    version: "0.1.0",
+  });
+
+  const toolCtx: ToolContext = {
+    state: gameState,
+    server: wsServer,
+    visibility,
+    remoteShapes,
+    remoteCardState,
+  };
+
+  // Register tools
+  for (const def of TOOL_DEFINITIONS) {
+    if (def.name === "loadDeck") {
+      mcp.tool(def.name, def.description, { deckList: z.string() }, async (args) => {
+        const cards = await loadDeckFromList(args.deckList);
+        gameState.initializeDeck(cards);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: true, deckSize: cards.length }) }],
+        };
+      });
+    } else if (def.name === "loadSnapshot") {
+      mcp.tool(def.name, def.description, { snapshot: z.string() }, async (args) => {
+        try {
+          const snap = JSON.parse(args.snapshot);
+          if (snap.cardState) {
+            gameState.initializeDeck(snap.cardState.deck ?? []);
+            if (snap.cardState.cards) {
+              gameState.sendToHand(snap.cardState.cards);
+            }
+          }
+          if (snap.shapes && Array.isArray(snap.shapes)) {
+            for (const shape of snap.shapes) {
+              gameState.addAgentShape(shape);
+            }
+          }
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ success: true }) }],
+          };
+        } catch (e) {
+          return {
+            content: [{ type: "text" as const, text: `Failed to load snapshot: ${e}` }],
+            isError: true,
+          };
+        }
+      });
+    } else {
+      const handlers = createToolHandlers(toolCtx);
+      const handler = handlers[def.name as keyof typeof handlers];
+      if (handler) {
+        // Build zod schema from inputSchema properties
+        const props = (def.inputSchema as { properties?: Record<string, unknown>; required?: string[] }).properties ?? {};
+        const required = (def.inputSchema as { required?: string[] }).required ?? [];
+        const zodShape: Record<string, z.ZodType> = {};
+        for (const [key, schema] of Object.entries(props)) {
+          const s = schema as { type: string; items?: { type: string } };
+          if (s.type === "string") {
+            zodShape[key] = required.includes(key) ? z.string() : z.string().optional();
+          } else if (s.type === "boolean") {
+            zodShape[key] = z.boolean().optional();
+          } else if (s.type === "number") {
+            zodShape[key] = z.number().optional();
+          } else if (s.type === "array") {
+            zodShape[key] = z.array(z.number()).optional();
+          } else if (s.type === "object") {
+            zodShape[key] = z.record(z.unknown()).optional();
+          }
+        }
+        mcp.tool(def.name, def.description, zodShape, async (args) => {
+          return handler(args as Record<string, unknown>);
+        });
+      }
+    }
+  }
+
+  // Start MCP over stdio
+  const transport = new StdioServerTransport();
+  await mcp.connect(transport);
+  console.error("[maginet-agent] MCP server running on stdio");
+}
+
+main().catch((error) => {
+  console.error("[maginet-agent] Fatal error:", error);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd maginet-agent && pnpm build`
+Expected: Compiles to `dist/` without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add maginet-agent/src/index.ts
+git commit -m "feat(agent): add CLI entry point wiring MCP + WebSocket + game state"
+```
+
+---
+
+## Task 8: Browser WebSocket transport (`websocket.ts`)
+
+A `SyncTransport`-compatible wrapper using the browser's native `WebSocket` API.
+
+**Files:**
+- Create: `src/sync/transport/websocket.ts`
+- Create: `src/sync/transport/websocket.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// src/sync/transport/websocket.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createWebSocketTransport } from "./websocket";
+
+// Mock WebSocket
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  url: string;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  sentMessages: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  // Test helpers
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  simulateMessage(data: string) {
+    this.onmessage?.({ data });
+  }
+
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+describe("createWebSocketTransport", () => {
+  let mockWs: MockWebSocket;
+
+  beforeEach(() => {
+    mockWs = new MockWebSocket("ws://localhost:3210");
+    vi.stubGlobal("WebSocket", class extends MockWebSocket {
+      constructor(url: string) {
+        super(url);
+        mockWs = this;
+      }
+    });
+  });
+
+  it("creates a transport with the correct interface", () => {
+    const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
+    expect(transport.start).toBeDefined();
+    expect(transport.stop).toBeDefined();
+    expect(transport.send).toBeDefined();
+    expect(transport.broadcast).toBeDefined();
+    expect(transport.onMessage).toBeDefined();
+    expect(transport.peers).toBeDefined();
+    expect(transport.localPeerId).toBeDefined();
+  });
+
+  it("connects on start and reports agent as peer", async () => {
+    const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
+
+    const startPromise = transport.start();
+    mockWs.simulateOpen();
+    await startPromise;
+
+    expect(transport.peers()).toEqual(["agent"]);
+  });
+
+  it("sends JSON-serialized envelopes", async () => {
+    const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
+
+    const startPromise = transport.start();
+    mockWs.simulateOpen();
+    await startPromise;
+
+    const envelope = { type: "test", payload: { value: 1 } };
+    transport.send("agent", envelope);
+
+    expect(mockWs.sentMessages).toHaveLength(1);
+    expect(JSON.parse(mockWs.sentMessages[0])).toEqual(envelope);
+  });
+
+  it("receives and deserializes messages", async () => {
+    const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
+
+    const startPromise = transport.start();
+    mockWs.simulateOpen();
+    await startPromise;
+
+    const received: unknown[] = [];
+    transport.onMessage((_, msg) => received.push(msg));
+
+    mockWs.simulateMessage(JSON.stringify({ type: "hello", payload: {} }));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ type: "hello", payload: {} });
+  });
+
+  it("calls onConnectionClose when socket closes", async () => {
+    const onClose = vi.fn();
+    const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
+
+    const startPromise = transport.start();
+    mockWs.simulateOpen();
+    await startPromise;
+
+    transport.onConnectionClose!(onClose);
+    mockWs.simulateClose();
+
+    expect(onClose).toHaveBeenCalledWith("agent");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test -- src/sync/transport/websocket.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the WebSocket transport**
+
+```typescript
+// src/sync/transport/websocket.ts
+import type {
+  SyncTransport,
+  SyncEnvelope,
+  SyncPeerId,
+} from "@vescofire/peersync";
+
+export interface WebSocketTransportOptions {
+  url: string;
+  agentPeerId?: string;
+  onConnected?: () => void;
+  onDisconnected?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export function createWebSocketTransport(
+  options: WebSocketTransportOptions
+): SyncTransport {
+  const agentPeerId = options.agentPeerId ?? "agent";
+  let ws: WebSocket | null = null;
+  let localId: string | null = null;
+  const messageListeners = new Set<
+    (fromPeerId: SyncPeerId, message: SyncEnvelope) => void
+  >();
+  const openListeners = new Set<(peerId: SyncPeerId) => void>();
+  const closeListeners = new Set<(peerId: SyncPeerId) => void>();
+
+  return {
+    start: async (localPeerId?: SyncPeerId) => {
+      localId = localPeerId ?? `browser-${Math.random().toString(36).substr(2, 6)}`;
+
+      return new Promise<void>((resolve, reject) => {
+        ws = new WebSocket(options.url);
+
+        ws.onopen = () => {
+          openListeners.forEach((listener) => listener(agentPeerId));
+          options.onConnected?.();
+          resolve();
+        };
+
+        ws.onerror = (event) => {
+          const error = new Error("WebSocket connection failed");
+          options.onError?.(error);
+          reject(error);
+        };
+
+        ws.onmessage = (event) => {
+          try {
+            const message = JSON.parse(
+              typeof event.data === "string" ? event.data : ""
+            ) as SyncEnvelope;
+            messageListeners.forEach((listener) =>
+              listener(agentPeerId, message)
+            );
+          } catch {
+            // Ignore malformed messages
+          }
+        };
+
+        ws.onclose = () => {
+          closeListeners.forEach((listener) => listener(agentPeerId));
+          options.onDisconnected?.();
+        };
+      });
+    },
+
+    stop: async () => {
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+    },
+
+    connect: async (_peerId: SyncPeerId) => {
+      // No-op: the WebSocket connection is established in start()
+    },
+
+    disconnect: (_peerId?: SyncPeerId) => {
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+    },
+
+    peers: () => {
+      return ws && ws.readyState === WebSocket.OPEN ? [agentPeerId] : [];
+    },
+
+    localPeerId: () => localId,
+
+    send: (_peerId: SyncPeerId, message: SyncEnvelope) => {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(message));
+      }
+    },
+
+    broadcast: (message: SyncEnvelope) => {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(message));
+      }
+    },
+
+    onMessage: (
+      callback: (fromPeerId: SyncPeerId, message: SyncEnvelope) => void
+    ) => {
+      messageListeners.add(callback);
+      return () => {
+        messageListeners.delete(callback);
+      };
+    },
+
+    onConnectionOpen: (callback: (peerId: SyncPeerId) => void) => {
+      openListeners.add(callback);
+      return () => {
+        openListeners.delete(callback);
+      };
+    },
+
+    onConnectionClose: (callback: (peerId: SyncPeerId) => void) => {
+      closeListeners.add(callback);
+      return () => {
+        closeListeners.delete(callback);
+      };
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test -- src/sync/transport/websocket.test.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sync/transport/websocket.ts src/sync/transport/websocket.test.ts
+git commit -m "feat(sync): add browser-side WebSocket transport"
+```
+
+---
+
+## Task 9: Wire WebSocket transport into peerStore
+
+Add the ability to optionally create a WebSocket transport alongside the PeerJS transport.
+
+**Files:**
+- Modify: `src/sync/react/peerStore.ts`
+
+- [ ] **Step 1: Add agent connection support to peerStore**
+
+Add a new `connectAgent` function to the store. This creates a secondary sync client using the WebSocket transport:
+
+In `src/sync/react/peerStore.ts`, add after the existing `usePeerStore` creation:
+
+```typescript
+// --- Add these imports at the top ---
+import { createWebSocketTransport } from "../transport/websocket";
+
+// --- Add after the usePeerStore definition ---
+
+let agentSyncClient: ReturnType<typeof createSyncClient> | null = null;
+let agentTransport: ReturnType<typeof createWebSocketTransport> | null = null;
+
+export const connectAgent = async (port: number = 3210): Promise<void> => {
+  if (agentSyncClient) {
+    await agentSyncClient.stop();
+  }
+
+  agentTransport = createWebSocketTransport({
+    url: `ws://localhost:${port}`,
+    onConnected: () => {
+      console.log("[maginet] Agent connected");
+    },
+    onDisconnected: () => {
+      console.log("[maginet] Agent disconnected");
+      agentSyncClient = null;
+      agentTransport = null;
+    },
+    onError: (error) => {
+      setPeerError(error);
+    },
+  });
+
+  agentSyncClient = createSyncClient({
+    roomId: "maginet-agent",
+    transport: agentTransport,
+  });
+
+  agentSyncClient.registerChannel(
+    createShapesSyncChannel({
+      getLocalPeerId: () => usePeerStore.getState().peer?.id ?? "browser",
+    })
+  );
+
+  await agentSyncClient.start();
+};
+
+export const disconnectAgent = async (): Promise<void> => {
+  if (agentSyncClient) {
+    await agentSyncClient.stop();
+    agentSyncClient = null;
+    agentTransport = null;
+  }
+};
+
+export const isAgentConnected = (): boolean => {
+  return agentTransport !== null && agentSyncClient !== null;
+};
+```
+
+- [ ] **Step 2: Verify the app still builds**
+
+Run: `pnpm build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/sync/react/peerStore.ts
+git commit -m "feat(sync): wire WebSocket transport for agent connections"
+```
+
+---
+
+## Task 10: "Connect Agent" UI in SetupScreen
+
+Add a small UI section to the multiplayer step in SetupScreen for connecting to the agent.
+
+**Files:**
+- Modify: `src/board/components/SetupScreen.tsx`
+
+- [ ] **Step 1: Add agent connection UI**
+
+Add an "Agent" panel next to the existing multiplayer panels. In `src/board/components/SetupScreen.tsx`:
+
+Add import:
+```typescript
+import { connectAgent, disconnectAgent, isAgentConnected } from "../../sync/react/peerStore";
+```
+
+Add state inside the `SetupScreen` component:
+```typescript
+const [agentPort, setAgentPort] = useState("3210");
+const [agentConnected, setAgentConnected] = useState(false);
+const [agentConnecting, setAgentConnecting] = useState(false);
+
+const handleConnectAgent = async () => {
+  setAgentConnecting(true);
+  try {
+    await connectAgent(parseInt(agentPort, 10));
+    setAgentConnected(true);
+  } catch {
+    setAgentConnected(false);
+  } finally {
+    setAgentConnecting(false);
+  }
+};
+
+const handleDisconnectAgent = () => {
+  void disconnectAgent();
+  setAgentConnected(false);
+};
+```
+
+Add this panel after the "Your ID" panel in the multiplayer step's `setup-grid`:
+
+```tsx
+<div className="setup-panel win-bevel flex flex-col gap-2 rounded bg-win-bg-light p-2.5 col-span-2 max-[720px]:col-span-1">
+  <label className="setup-label text-[11px] tracking-[0.12em] uppercase text-win-text-muted">
+    AI Agent
+  </label>
+  <div className="setup-input-row flex gap-2.5 items-center max-[720px]:flex-col max-[720px]:items-stretch">
+    <Input
+      className="setup-input w-24 p-3 text-[13px] leading-[1.4] shadow-none"
+      type="text"
+      value={agentPort}
+      onChange={(event) => setAgentPort(event.target.value)}
+      placeholder="Port"
+      disabled={agentConnected}
+    />
+    {agentConnected ? (
+      <Button
+        type="button"
+        className="setup-button ghost rounded px-3.5 py-2 text-xs bg-win-header-bg"
+        onClick={handleDisconnectAgent}
+      >
+        Disconnect
+      </Button>
+    ) : (
+      <Button
+        type="button"
+        className="setup-button primary rounded px-3.5 py-2 text-xs bg-win-hover hover:bg-[#f5f5f5]"
+        onClick={handleConnectAgent}
+        disabled={agentConnecting}
+      >
+        {agentConnecting ? "Connecting..." : "Connect Agent"}
+      </Button>
+    )}
+  </div>
+  <div className="setup-hint text-[11px] text-win-text-muted">
+    {agentConnected
+      ? "Agent connected. It will appear as a player on the board."
+      : "Connect to a local MCP agent for AI play or copilot advice."}
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Verify it renders correctly**
+
+Run: `pnpm dev`
+Navigate to `http://localhost:5173`, enter a deck, go to multiplayer step. Verify the "AI Agent" panel appears with a port input and "Connect Agent" button.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/board/components/SetupScreen.tsx
+git commit -m "feat(ui): add Connect Agent button to setup screen"
+```
+
+---
+
+## Task 11: End-to-end integration test
+
+Test the full loop: MCP server starts, browser transport connects, agent draws a card and it appears on the browser's board.
+
+**Files:**
+- Create: `maginet-agent/src/__tests__/e2e.integration.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+```typescript
+// maginet-agent/src/__tests__/e2e.integration.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import { WebSocket } from "ws";
+import { AgentWebSocketServer } from "../server.js";
+import { AgentGameState } from "../state.js";
+import { createToolHandlers } from "../mcp.js";
+import type { Shape } from "../../../src/types/canvas.js";
+
+const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+const waitFor = async (
+  assertion: () => void,
+  timeoutMs = 2000,
+  pollMs = 10
+) => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try { assertion(); return; }
+    catch { await wait(pollMs); }
+  }
+  assertion();
+};
+
+describe("Agent E2E", () => {
+  let server: AgentWebSocketServer | null = null;
+
+  afterEach(async () => {
+    if (server) { await server.stop(); server = null; }
+  });
+
+  it("agent loads deck, draws card, plays to board, browser receives shape", async () => {
+    // 1. Start agent server
+    server = new AgentWebSocketServer({ port: 0 });
+    const port = await server.start();
+
+    // 2. Create game state and tool handlers
+    const state = new AgentGameState();
+    const remoteShapes: Record<string, Shape[]> = {};
+    const handlers = createToolHandlers({
+      state,
+      server: server as any,
+      visibility: "full",
+      remoteShapes,
+      remoteCardState: null,
+    });
+
+    // 3. Simulate browser connecting
+    const browserReceived: unknown[] = [];
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+    ws.on("message", (data) => browserReceived.push(JSON.parse(data.toString())));
+
+    // 4. Initialize deck with pre-made cards (skip Scryfall)
+    state.initializeDeck([
+      { id: "card-1", src: ["https://example.com/bolt.png"] },
+      { id: "card-2", src: ["https://example.com/mountain.png"] },
+    ]);
+
+    // 5. Draw a card
+    const drawResult = await handlers.drawCard({});
+    expect(drawResult.isError).toBeUndefined();
+    expect(state.getHand()).toHaveLength(1);
+
+    // 6. Play the card
+    const cardId = state.getHand()[0].id;
+    const playResult = await handlers.playCard({
+      cardId,
+      position: [300, 300],
+    });
+    expect(playResult.isError).toBeUndefined();
+    expect(state.getHand()).toHaveLength(0);
+    expect(state.getAgentShapes()).toHaveLength(1);
+
+    // 7. Verify shape was created correctly
+    const shape = state.getAgentShapes()[0];
+    expect(shape.point).toEqual([300, 300]);
+    expect(shape.type).toBe("image");
+    expect(shape.src).toEqual(["https://example.com/bolt.png"]);
+    expect(shape.isFlipped).toBe(false);
+
+    // 8. Tap the card
+    await handlers.tapCard({ shapeId: shape.id });
+    expect(state.getAgentShapes()[0].rotation).toBe(90);
+
+    // 9. Get game state
+    const gameState = await handlers.getGameState({});
+    const parsed = JSON.parse(gameState.content[0].text);
+    expect(parsed.agentHand).toHaveLength(0);
+    expect(parsed.agentDeckSize).toBe(1);
+    expect(parsed.boardShapes.agent).toHaveLength(1);
+
+    ws.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd maginet-agent && pnpm test`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add maginet-agent/src/__tests__/e2e.integration.test.ts
+git commit -m "test(agent): add end-to-end integration test"
+```
+
+---
+
+## Task 12: Build verification and MCP config
+
+Final verification that everything builds and works together.
+
+**Files:**
+- No new files. Verification only.
+
+- [ ] **Step 1: Build the agent package**
+
+Run: `cd maginet-agent && pnpm build`
+Expected: Compiles to `dist/` without errors.
+
+- [ ] **Step 2: Build the browser app**
+
+Run: `pnpm build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run all tests**
+
+Run: `cd maginet-agent && pnpm test && cd .. && pnpm test`
+Expected: All tests pass in both packages.
+
+- [ ] **Step 4: Run lint**
+
+Run: `pnpm lint`
+Expected: No warnings (or only pre-existing ones).
+
+- [ ] **Step 5: Log the MCP config for Claude Code**
+
+The user should add this to their Claude Code MCP config (`.claude/settings.json` or project `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "maginet": {
+      "command": "node",
+      "args": ["./maginet-agent/dist/index.js", "--port", "3210", "--visibility", "fair"]
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Commit any remaining changes**
+
+```bash
+git add -A
+git commit -m "chore: finalize maginet-agent build and verify integration"
+```

--- a/docs/superpowers/specs/2026-03-28-maginet-agent-design.md
+++ b/docs/superpowers/specs/2026-03-28-maginet-agent-design.md
@@ -1,0 +1,217 @@
+# Maginet Agent — Design Spec
+
+## Overview
+
+An MCP server that lets Claude Code play Magic: The Gathering on a live Maginet board. The agent connects to the browser via WebSocket, syncs state through the existing transport-agnostic sync engine, and exposes game actions as MCP tools.
+
+Two modes:
+- **Opponent mode** — Agent has its own deck/hand and plays as a separate peer against the human.
+- **Copilot mode** — Agent observes the human's game state (read-only) and gives advice when asked.
+
+Both modes run from the same MCP server. In opponent mode, the human can also ask for copilot-style advice since the agent has access to observation tools alongside action tools.
+
+## Architecture
+
+```
+┌─────────────────┐         stdio          ┌──────────────────────┐
+│   Claude Code   │◄──────────────────────►│   MCP Server (Node)  │
+│   (LLM agent)   │     MCP protocol       │                      │
+└─────────────────┘                        │  - Game state (own)  │
+                                           │  - Tool handlers     │
+                                           │  - Visibility filter │
+                                           │  - WS server :PORT   │
+                                           └──────────┬───────────┘
+                                                      │ WebSocket
+                                                      │
+                                           ┌──────────▼───────────┐
+                                           │   Maginet (Browser)  │
+                                           │                      │
+                                           │  - WS Transport      │
+                                           │    (new, alongside   │
+                                           │     PeerJS)          │
+                                           │  - Sync channels     │
+                                           │  - Normal UI         │
+                                           └──────────────────────┘
+```
+
+Three components:
+1. **MCP Server** — Node.js process spawned by Claude Code via stdio. Runs a WebSocket server on a local port. In opponent mode, holds the agent's own card state using the shared `cardReducer` logic.
+2. **WebSocket Transport** — New `SyncTransport` implementation in the browser. Connects to `ws://localhost:PORT`. Plugs into the existing sync channel system — shapes and card actions flow through the same diff/patch/snapshot model.
+3. **Claude Code** — Calls MCP tools. Decision-making comes from the LLM's natural MTG knowledge.
+
+## User Flow
+
+### Playing against the agent (opponent mode)
+
+1. Configure the MCP server in Claude Code settings (one-time setup).
+2. Open Maginet in the browser (local or deployed). Load your deck normally.
+3. Click "Connect Agent" on the setup screen. Browser connects to `ws://localhost:3210`.
+4. Tell Claude: "Load this deck: 4 Lightning Bolt, 20 Mountain... and play a game against me."
+5. Claude draws its opening hand, you draw yours. You take turns. Claude's moves appear live on your canvas.
+6. Ask Claude "What should I play?" at any time for advice (opponent mode includes observation tools).
+
+### Using copilot mode
+
+1. Same setup — open Maginet, connect agent.
+2. Play your game normally (against a human via PeerJS, or solo).
+3. Ask Claude: "What's my best play here?" — it reads your hand, the board, and advises.
+
+## MCP Tool Surface
+
+### Observation Tools (both modes)
+
+| Tool | Parameters | Returns |
+|------|-----------|---------|
+| `getGameState` | none | Full snapshot: board shapes, hand, deck size, opponent visible cards, opponent hand count |
+| `getHand` | none | Array of cards in hand (name, image URLs, card ID) |
+| `getBoardState` | none | All shapes on canvas: positions, tap state, counters, z-order, isFlipped |
+| `getDeckInfo` | none | Deck size. In `full` visibility: deck order and card contents |
+
+### Action Tools (opponent mode only)
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `loadDeck` | `deckList: string` | Import deck list (MTGO format), fetch from Scryfall, initialize deck |
+| `loadSnapshot` | `snapshot: string` | Load a debug snapshot JSON to resume a game state |
+| `drawCard` | none | Draw top card from deck to hand |
+| `mulligan` | none | Shuffle hand back into deck |
+| `playCard` | `cardId: string, position?: [x, y], faceDown?: boolean` | Play a card from hand onto the board |
+| `tapCard` | `shapeId: string` | Toggle tap/untap (0 deg / 90 deg rotation) |
+| `untapAll` | none | Untap all agent's cards on the board |
+| `sendToHand` | `shapeId: string` | Return a board card to hand |
+| `sendToDeck` | `shapeId: string, position: "top" \| "bottom"` | Return a board card to deck |
+| `shuffleDeck` | none | Shuffle the deck |
+| `addCounter` | `shapeId: string, counter: Counter` | Add or modify a counter on a card |
+| `removeCounter` | `shapeId: string, label: string` | Remove a counter by label |
+| `flipCard` | `shapeId: string` | Toggle face-down/face-up |
+| `transformCard` | `shapeId: string` | Switch to next card face (double-faced cards) |
+
+## Visibility
+
+Controlled by `--visibility` CLI flag.
+
+### `fair` (default)
+- Agent's own hand: visible.
+- Agent's deck: size only, no peeking at order/contents.
+- Opponent's hand: count only, no contents.
+- Board: fully visible (public information).
+
+### `full`
+- Everything visible: deck order, opponent hand contents.
+- Useful for debugging, testing, and copilot advice on your own hand.
+
+In copilot mode, `full` visibility is the natural choice — the agent needs to see your hand to advise you.
+
+## WebSocket Transport (Browser Side)
+
+New file: `src/sync/transport/websocket.ts`
+
+Implements the existing `SyncTransport` interface:
+- `connect()` — Opens WebSocket to `ws://localhost:PORT`
+- `send(envelope)` — Serializes `SyncEnvelope` as JSON, sends over WS
+- `onMessage(callback)` — Deserializes incoming JSON into `SyncEnvelope`
+- `disconnect()` — Closes WebSocket
+
+Message format: same `SyncEnvelope<TType, TPayload>` wire format used by PeerJS transport, serialized as JSON. No new protocol.
+
+The sync client handles snapshots on connect and patches on changes — same behavior as PeerJS peers.
+
+## State Sync
+
+### Browser to Agent
+The browser pushes state through the WebSocket sync channel:
+- Shape diffs (cards played, tapped, moved, removed)
+- Card action broadcasts (draw, mulligan — with `actionId` for ordering)
+
+The MCP server maintains a local mirror of the board state, updated via the existing `diff/apply/snapshot` model.
+
+### Agent to Browser (opponent mode)
+When the agent takes an action (e.g. `playCard`):
+1. Updates local card state (deck/hand via `cardReducer`)
+2. Creates the shape, adds to local shape list
+3. Broadcasts diff through WebSocket sync channel
+4. Browser receives patch, renders the new card on canvas
+
+### Agent to Browser (copilot mode)
+Read-only. Agent never broadcasts state changes. Only receives updates.
+
+### State ownership
+
+| State | Opponent mode | Copilot mode |
+|-------|--------------|--------------|
+| Agent's deck/hand | MCP server | N/A (reads browser state) |
+| Board shapes | Shared (sync) | Browser (agent reads) |
+| Human's deck/hand | Browser | Browser (agent reads) |
+
+## Connection Lifecycle
+
+### Startup
+1. Claude Code spawns: `maginet-agent --port 3210 --visibility fair`
+2. MCP server starts WebSocket server on specified port
+3. All tools (observation + action) are always registered. Mode is implicit: calling `loadDeck` puts the agent in opponent mode (it now has its own state). Without loading a deck, the agent is effectively a copilot (observation-only).
+4. Server waits for browser connection
+
+### Browser connection
+1. User clicks "Connect Agent" or navigates with `?agent=PORT`
+2. Browser opens `ws://localhost:PORT`
+3. WebSocket transport registers with sync client
+4. Sync client sends full snapshot (existing behavior for new peers)
+5. UI shows "Agent connected" indicator
+
+### Disconnection
+- Browser shows "Agent disconnected" on WebSocket drop
+- Auto-reconnect with backoff
+- MCP server preserves state (opponent mode) so game resumes on reconnect
+
+### Coexistence with PeerJS
+Both transports run simultaneously. The sync client already supports multiple peers. Valid configurations:
+- You + Agent (opponent) — play against AI
+- You + Human (PeerJS) + Agent (copilot) — play human with AI advice
+- You + Agent (opponent) — play AI and ask for advice too
+
+## Project Structure
+
+```
+src/
+├── sync/
+│   └── transport/
+│       ├── peerjs.ts              # Existing — unchanged
+│       └── websocket.ts           # NEW — WebSocketTransport
+├── board/
+│   └── components/
+│       └── SetupScreen.tsx        # Modified — "Connect Agent" UI
+│
+maginet-agent/                     # NEW — standalone Node.js package
+├── package.json
+├── tsconfig.json
+├── src/
+│   ├── index.ts                   # CLI entry — parses args, starts WS + MCP
+│   ├── server.ts                  # WebSocket server + sync handling
+│   ├── mcp.ts                     # MCP tool definitions + handlers
+│   ├── state.ts                   # Agent card state (reuses cardReducer)
+│   └── visibility.ts              # Fair/full state filtering
+```
+
+- `maginet-agent/` is a monorepo sibling that imports shared code from `src/` (cardReducer, SyncEnvelope, types, SyncChannelPlugin interface).
+- Browser changes are minimal: one new transport file + small UI addition.
+
+### Claude Code MCP config
+
+```json
+{
+  "mcpServers": {
+    "maginet": {
+      "command": "node",
+      "args": ["./maginet-agent/dist/index.js", "--port", "3210", "--visibility", "fair"]
+    }
+  }
+}
+```
+
+## Out of Scope
+
+- Built-in strategy engine — the LLM handles all decision-making.
+- Turn/phase enforcement — the agent follows MTG rules via LLM knowledge, not programmatic validation.
+- Opponent hand tracking or hidden information inference.
+- Graveyard/exile zones — not yet modeled in Maginet.
+- Life total management — currently manual text shapes in the app.

--- a/maginet-agent/package.json
+++ b/maginet-agent/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "maginet-agent",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.5.10",
+    "typescript": "^5.2.2",
+    "vitest": "^4.0.18"
+  }
+}

--- a/maginet-agent/package.json
+++ b/maginet-agent/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/ws": "^8.5.10",

--- a/maginet-agent/pnpm-lock.yaml
+++ b/maginet-agent/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       ws:
         specifier: ^8.18.0
         version: 8.20.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/ws':
         specifier: ^8.5.10

--- a/maginet-agent/pnpm-lock.yaml
+++ b/maginet-agent/pnpm-lock.yaml
@@ -1,0 +1,1545 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.1
+        version: 1.28.0(zod@4.3.6)
+      ws:
+        specifier: ^8.18.0
+        version: 8.20.0
+    devDependencies:
+      '@types/ws':
+        specifier: ^8.5.10
+        version: 8.18.1
+      typescript:
+        specifier: ^5.2.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0))
+
+packages:
+
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@1.28.0':
+    resolution: {integrity: sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.12':
+    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.9:
+    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rolldown@1.0.0-rc.12:
+    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  vite@8.0.3:
+    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+snapshots:
+
+  '@emnapi/core@1.9.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@hono/node-server@1.19.11(hono@4.12.9)':
+    dependencies:
+      hono: 4.12.9
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@1.28.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.9)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.9
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.122.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.12': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/node@25.5.0':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.5.0
+
+  '@vitest/expect@4.1.2':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.2(vite@8.0.3(@types/node@25.5.0))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.3(@types/node@25.5.0)
+
+  '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.2':
+    dependencies:
+      '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.2': {}
+
+  '@vitest/utils@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  assertion-error@2.0.1: {}
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  chai@6.2.2: {}
+
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  depd@2.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  escape-html@1.0.3: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
+  expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.9: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jose@6.2.2: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  negotiator@1.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.0: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  require-from-string@2.0.2: {}
+
+  rolldown@1.0.0-rc.12:
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
+
+  std-env@4.0.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  toidentifier@1.0.1: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typescript@5.9.3: {}
+
+  undici-types@7.18.2: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
+
+  vite@8.0.3(@types/node@25.5.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.12
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.5.0
+      fsevents: 2.3.3
+
+  vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@types/node@25.5.0)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@types/node@25.5.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.3(@types/node@25.5.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - msw
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
+
+  zod@4.3.6: {}

--- a/maginet-agent/src/__tests__/e2e.integration.test.ts
+++ b/maginet-agent/src/__tests__/e2e.integration.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { WebSocket } from "ws";
+import { AgentWebSocketServer } from "../server.js";
+import { AgentGameState } from "../state.js";
+import { createToolHandlers } from "../mcp.js";
+import type { Shape } from "../state.js";
+
+const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+const waitFor = async (
+  assertion: () => void,
+  timeoutMs = 2000,
+  pollMs = 10
+) => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try { assertion(); return; }
+    catch { await wait(pollMs); }
+  }
+  assertion();
+};
+
+describe("Agent E2E", () => {
+  let server: AgentWebSocketServer | null = null;
+
+  afterEach(async () => {
+    if (server) { await server.stop(); server = null; }
+  });
+
+  it("agent loads deck, draws card, plays to board, taps card, observes state", async () => {
+    // 1. Start agent server
+    server = new AgentWebSocketServer({ port: 0 });
+    const port = await server.start();
+
+    // 2. Create game state and tool handlers
+    const state = new AgentGameState();
+    const remoteShapes: Record<string, Shape[]> = {};
+    const handlers = createToolHandlers({
+      state,
+      server: server as any,
+      visibility: "full",
+      remoteShapes,
+      remoteCardState: null,
+    });
+
+    // 3. Simulate browser connecting
+    const browserReceived: unknown[] = [];
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+    ws.on("message", (data) => browserReceived.push(JSON.parse(data.toString())));
+
+    // 4. Initialize deck with pre-made cards (skip Scryfall)
+    state.initializeDeck([
+      { id: "card-1", src: ["https://example.com/bolt.png"] },
+      { id: "card-2", src: ["https://example.com/mountain.png"] },
+    ]);
+
+    // 5. Draw a card
+    const drawResult = await handlers.drawCard({});
+    expect(drawResult.isError).toBeUndefined();
+    expect(state.getHand()).toHaveLength(1);
+
+    // 6. Play the card
+    const cardId = state.getHand()[0].id;
+    const playResult = await handlers.playCard({
+      cardId,
+      position: [300, 300],
+    });
+    expect(playResult.isError).toBeUndefined();
+    expect(state.getHand()).toHaveLength(0);
+    expect(state.getAgentShapes()).toHaveLength(1);
+
+    // 7. Verify shape was created correctly
+    const shape = state.getAgentShapes()[0];
+    expect(shape.point).toEqual([300, 300]);
+    expect(shape.type).toBe("image");
+    expect(shape.src).toEqual(["https://example.com/bolt.png"]);
+    expect(shape.isFlipped).toBe(false);
+
+    // 8. Tap the card
+    await handlers.tapCard({ shapeId: shape.id });
+    expect(state.getAgentShapes()[0].rotation).toBe(90);
+
+    // 9. Get game state
+    const gameState = await handlers.getGameState({});
+    const parsed = JSON.parse(gameState.content[0].text);
+    expect(parsed.agentHand).toHaveLength(0);
+    expect(parsed.agentDeckSize).toBe(1);
+    expect(parsed.boardShapes.agent).toHaveLength(1);
+
+    ws.close();
+  });
+});

--- a/maginet-agent/src/__tests__/e2e.integration.test.ts
+++ b/maginet-agent/src/__tests__/e2e.integration.test.ts
@@ -5,20 +5,6 @@ import { AgentGameState } from "../state.js";
 import { createToolHandlers } from "../mcp.js";
 import type { Shape } from "../state.js";
 
-const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
-const waitFor = async (
-  assertion: () => void,
-  timeoutMs = 2000,
-  pollMs = 10
-) => {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    try { assertion(); return; }
-    catch { await wait(pollMs); }
-  }
-  assertion();
-};
-
 describe("Agent E2E", () => {
   let server: AgentWebSocketServer | null = null;
 
@@ -36,7 +22,7 @@ describe("Agent E2E", () => {
     const remoteShapes: Record<string, Shape[]> = {};
     const handlers = createToolHandlers({
       state,
-      server: server as any,
+      server: server as unknown as AgentWebSocketServer,
       visibility: "full",
       remoteShapes,
       remoteCardState: null,

--- a/maginet-agent/src/__tests__/e2e.integration.test.ts
+++ b/maginet-agent/src/__tests__/e2e.integration.test.ts
@@ -26,6 +26,7 @@ describe("Agent E2E", () => {
       visibility: "full",
       remoteShapes,
       remoteCardState: null,
+      actionLog: [],
     });
 
     // 3. Simulate browser connecting

--- a/maginet-agent/src/__tests__/mcp.test.ts
+++ b/maginet-agent/src/__tests__/mcp.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createToolHandlers, type ToolContext } from "../mcp.js";
+import { AgentGameState } from "../state.js";
+
+const makeCard = (id: string) => ({ id, src: [`https://example.com/${id}.png`] });
+
+// Minimal mock for server
+const mockServer = () => {
+  const sent: unknown[] = [];
+  return {
+    send: (msg: unknown) => { sent.push(msg); },
+    isConnected: () => true,
+    getSent: () => sent,
+  };
+};
+
+describe("MCP tool handlers", () => {
+  let state: AgentGameState;
+  let server: ReturnType<typeof mockServer>;
+  let handlers: ReturnType<typeof createToolHandlers>;
+
+  beforeEach(() => {
+    state = new AgentGameState();
+    server = mockServer();
+    handlers = createToolHandlers({
+      state,
+      server: server as any,
+      visibility: "full",
+      remoteShapes: {},
+      remoteCardState: null,
+    });
+  });
+
+  it("getHand returns empty hand initially", async () => {
+    const result = await handlers.getHand({});
+    expect(result.content[0].text).toContain("[]");
+  });
+
+  it("drawCard draws a card and returns it", async () => {
+    state.initializeDeck([makeCard("bolt")]);
+    const result = await handlers.drawCard({});
+    expect(result.content[0].text).toContain("bolt");
+    expect(state.getHand()).toHaveLength(1);
+  });
+
+  it("drawCard fails on empty deck", async () => {
+    const result = await handlers.drawCard({});
+    expect(result.isError).toBe(true);
+  });
+
+  it("playCard plays a card from hand", async () => {
+    state.initializeDeck([makeCard("bolt")]);
+    state.drawCard();
+    const cardId = state.getHand()[0].id;
+    const result = await handlers.playCard({ cardId });
+    expect(result.isError).toBeUndefined();
+    expect(state.getHand()).toHaveLength(0);
+    expect(state.getAgentShapes()).toHaveLength(1);
+  });
+
+  it("playCard fails when card not in hand", async () => {
+    const result = await handlers.playCard({ cardId: "nope" });
+    expect(result.isError).toBe(true);
+  });
+
+  it("tapCard toggles rotation on agent shape", async () => {
+    state.initializeDeck([makeCard("bolt")]);
+    state.drawCard();
+    const cardId = state.getHand()[0].id;
+    await handlers.playCard({ cardId });
+    const shapeId = state.getAgentShapes()[0].id;
+
+    await handlers.tapCard({ shapeId });
+    expect(state.getAgentShapes()[0].rotation).toBe(90);
+
+    await handlers.tapCard({ shapeId });
+    expect(state.getAgentShapes()[0].rotation).toBe(0);
+  });
+
+  it("getGameState respects full visibility", async () => {
+    state.initializeDeck([makeCard("a"), makeCard("b")]);
+    state.drawCard();
+
+    const result = await handlers.getGameState({});
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.agentDeckContents).toBeDefined();
+    expect(parsed.agentDeckContents).toHaveLength(1);
+  });
+
+  it("getGameState respects fair visibility", async () => {
+    state.initializeDeck([makeCard("a"), makeCard("b")]);
+    state.drawCard();
+
+    const fairHandlers = createToolHandlers({
+      state,
+      server: server as any,
+      visibility: "fair",
+      remoteShapes: {},
+      remoteCardState: null,
+    });
+
+    const result = await fairHandlers.getGameState({});
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.agentDeckContents).toBeUndefined();
+  });
+
+  it("mulligan shuffles hand back to deck", async () => {
+    state.initializeDeck([makeCard("a"), makeCard("b"), makeCard("c")]);
+    state.drawCard();
+    state.drawCard();
+    expect(state.getHand()).toHaveLength(2);
+
+    await handlers.mulligan({});
+    expect(state.getHand()).toHaveLength(0);
+    expect(state.getDeckSize()).toBe(3);
+  });
+
+  it("getBoardState returns shapes", async () => {
+    const boardHandlers = createToolHandlers({
+      state,
+      server: server as any,
+      visibility: "full",
+      remoteShapes: {
+        "browser-peer": [
+          { id: "s1", point: [0, 0], size: [100, 100], type: "image" as const, srcIndex: 0 },
+        ],
+      },
+      remoteCardState: null,
+    });
+
+    const result = await boardHandlers.getBoardState({});
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed["browser-peer"]).toHaveLength(1);
+  });
+});

--- a/maginet-agent/src/__tests__/mcp.test.ts
+++ b/maginet-agent/src/__tests__/mcp.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { createToolHandlers, type ToolContext } from "../mcp.js";
+import { createToolHandlers } from "../mcp.js";
+import type { AgentWebSocketServer } from "../server.js";
 import { AgentGameState } from "../state.js";
 
 const makeCard = (id: string) => ({ id, src: [`https://example.com/${id}.png`] });
@@ -24,7 +25,7 @@ describe("MCP tool handlers", () => {
     server = mockServer();
     handlers = createToolHandlers({
       state,
-      server: server as any,
+      server: server as unknown as AgentWebSocketServer,
       visibility: "full",
       remoteShapes: {},
       remoteCardState: null,
@@ -93,7 +94,7 @@ describe("MCP tool handlers", () => {
 
     const fairHandlers = createToolHandlers({
       state,
-      server: server as any,
+      server: server as unknown as AgentWebSocketServer,
       visibility: "fair",
       remoteShapes: {},
       remoteCardState: null,
@@ -118,7 +119,7 @@ describe("MCP tool handlers", () => {
   it("getBoardState returns shapes", async () => {
     const boardHandlers = createToolHandlers({
       state,
-      server: server as any,
+      server: server as unknown as AgentWebSocketServer,
       visibility: "full",
       remoteShapes: {
         "browser-peer": [

--- a/maginet-agent/src/__tests__/mcp.test.ts
+++ b/maginet-agent/src/__tests__/mcp.test.ts
@@ -29,6 +29,7 @@ describe("MCP tool handlers", () => {
       visibility: "full",
       remoteShapes: {},
       remoteCardState: null,
+      actionLog: [],
     });
   });
 
@@ -98,6 +99,7 @@ describe("MCP tool handlers", () => {
       visibility: "fair",
       remoteShapes: {},
       remoteCardState: null,
+      actionLog: [],
     });
 
     const result = await fairHandlers.getGameState({});
@@ -127,6 +129,7 @@ describe("MCP tool handlers", () => {
         ],
       },
       remoteCardState: null,
+      actionLog: [],
     });
 
     const result = await boardHandlers.getBoardState({});

--- a/maginet-agent/src/__tests__/server.integration.test.ts
+++ b/maginet-agent/src/__tests__/server.integration.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { WebSocket } from "ws";
+import { AgentWebSocketServer } from "../server.js";
+
+const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const waitFor = async (
+  assertion: () => void,
+  timeoutMs = 2000,
+  pollMs = 10
+) => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try { assertion(); return; }
+    catch { await wait(pollMs); }
+  }
+  assertion();
+};
+
+describe("AgentWebSocketServer", () => {
+  let server: AgentWebSocketServer | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+  });
+
+  it("starts and accepts a WebSocket connection", async () => {
+    server = new AgentWebSocketServer({ port: 0 });
+    const port = await server.start();
+
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+
+    await waitFor(() => {
+      expect(server!.isConnected()).toBe(true);
+    });
+
+    ws.close();
+  });
+
+  it("receives messages from browser client", async () => {
+    server = new AgentWebSocketServer({ port: 0 });
+    const port = await server.start();
+
+    const received: unknown[] = [];
+    server.onMessage((msg) => received.push(msg));
+
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+
+    ws.send(JSON.stringify({ type: "test", payload: { value: 42 } }));
+
+    await waitFor(() => {
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual({ type: "test", payload: { value: 42 } });
+    });
+
+    ws.close();
+  });
+
+  it("sends messages to browser client", async () => {
+    server = new AgentWebSocketServer({ port: 0 });
+    const port = await server.start();
+
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+
+    const received: unknown[] = [];
+    ws.on("message", (data) => received.push(JSON.parse(data.toString())));
+
+    server.send({ type: "hello", payload: { from: "agent" } });
+
+    await waitFor(() => {
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual({ type: "hello", payload: { from: "agent" } });
+    });
+
+    ws.close();
+  });
+
+  it("detects disconnection", async () => {
+    server = new AgentWebSocketServer({ port: 0 });
+    const port = await server.start();
+
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve) => ws.on("open", resolve));
+
+    await waitFor(() => expect(server!.isConnected()).toBe(true));
+
+    ws.close();
+
+    await waitFor(() => expect(server!.isConnected()).toBe(false));
+  });
+});

--- a/maginet-agent/src/__tests__/state.test.ts
+++ b/maginet-agent/src/__tests__/state.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { AgentGameState } from "../state.js";
+
+const makeCard = (id: string, src = [`https://example.com/${id}.png`]) => ({
+  id,
+  src,
+});
+
+describe("AgentGameState", () => {
+  let state: AgentGameState;
+
+  beforeEach(() => {
+    state = new AgentGameState();
+  });
+
+  it("initializes with empty deck and hand", () => {
+    expect(state.getHand()).toEqual([]);
+    expect(state.getDeckSize()).toBe(0);
+  });
+
+  it("initializes a deck", () => {
+    const cards = [makeCard("a"), makeCard("b"), makeCard("c")];
+    state.initializeDeck(cards);
+    expect(state.getDeckSize()).toBe(3);
+    expect(state.getHand()).toEqual([]);
+  });
+
+  it("draws a card from deck to hand", () => {
+    state.initializeDeck([makeCard("a"), makeCard("b")]);
+    const drawn = state.drawCard();
+    expect(drawn).toBeDefined();
+    expect(state.getHand()).toHaveLength(1);
+    expect(state.getDeckSize()).toBe(1);
+  });
+
+  it("returns null when drawing from empty deck", () => {
+    const drawn = state.drawCard();
+    expect(drawn).toBeNull();
+  });
+
+  it("mulligans hand back into deck", () => {
+    state.initializeDeck([makeCard("a"), makeCard("b"), makeCard("c")]);
+    state.drawCard();
+    state.drawCard();
+    expect(state.getHand()).toHaveLength(2);
+    state.mulligan();
+    expect(state.getHand()).toHaveLength(0);
+    expect(state.getDeckSize()).toBe(3);
+  });
+
+  it("plays a card from hand and returns it", () => {
+    state.initializeDeck([makeCard("a")]);
+    state.drawCard();
+    const hand = state.getHand();
+    const cardId = hand[0].id;
+    const played = state.playCard(cardId);
+    expect(played).toBeDefined();
+    expect(played!.src).toEqual(["https://example.com/a.png"]);
+    expect(state.getHand()).toHaveLength(0);
+  });
+
+  it("returns null when playing a card not in hand", () => {
+    const played = state.playCard("nonexistent");
+    expect(played).toBeNull();
+  });
+
+  it("sends a card back to hand", () => {
+    const card = makeCard("returned");
+    state.sendToHand([card]);
+    expect(state.getHand()).toHaveLength(1);
+    expect(state.getHand()[0].src).toEqual(card.src);
+  });
+
+  it("sends a card to deck top", () => {
+    state.initializeDeck([makeCard("a")]);
+    state.sendToDeck([makeCard("top")], "top");
+    expect(state.getDeckSize()).toBe(2);
+    const drawn = state.drawCard();
+    expect(drawn!.src).toEqual(["https://example.com/top.png"]);
+  });
+
+  it("sends a card to deck bottom", () => {
+    state.initializeDeck([makeCard("a")]);
+    state.sendToDeck([makeCard("bottom")], "bottom");
+    expect(state.getDeckSize()).toBe(2);
+    const drawn = state.drawCard();
+    expect(drawn!.src).toEqual(["https://example.com/a.png"]);
+  });
+
+  it("shuffles the deck", () => {
+    const cards = Array.from({ length: 20 }, (_, i) => makeCard(`card-${i}`));
+    state.initializeDeck(cards);
+    const before = state.getDeckContents().map((c) => c.id);
+    state.shuffleDeck();
+    const after = state.getDeckContents().map((c) => c.id);
+    expect(after).not.toEqual(before);
+  });
+
+  it("tracks agent shapes", () => {
+    expect(state.getAgentShapes()).toEqual([]);
+    const shape = {
+      id: "s1",
+      point: [100, 200],
+      size: [100, 100],
+      type: "image" as const,
+      srcIndex: 0,
+      src: ["https://example.com/card.png"],
+    };
+    state.addAgentShape(shape);
+    expect(state.getAgentShapes()).toHaveLength(1);
+    state.removeAgentShape("s1");
+    expect(state.getAgentShapes()).toEqual([]);
+  });
+
+  it("updates an agent shape", () => {
+    const shape = {
+      id: "s1",
+      point: [100, 200],
+      size: [100, 100],
+      type: "image" as const,
+      srcIndex: 0,
+    };
+    state.addAgentShape(shape);
+    state.updateAgentShape("s1", { rotation: 90 });
+    expect(state.getAgentShapes()[0].rotation).toBe(90);
+  });
+
+  it("exposes cardState for sync", () => {
+    state.initializeDeck([makeCard("a")]);
+    const cardState = state.getCardState();
+    expect(cardState.deck).toHaveLength(1);
+    expect(cardState.cards).toHaveLength(0);
+  });
+});

--- a/maginet-agent/src/__tests__/visibility.test.ts
+++ b/maginet-agent/src/__tests__/visibility.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { filterGameState, type RawGameState } from "../visibility.js";
+
+const makeCard = (id: string) => ({ id, src: [`https://example.com/${id}.png`] });
+const makeShape = (id: string) => ({
+  id,
+  point: [0, 0],
+  size: [100, 100],
+  type: "image" as const,
+  srcIndex: 0,
+  src: [`https://example.com/${id}.png`],
+});
+
+const rawState: RawGameState = {
+  agentHand: [makeCard("a1"), makeCard("a2")],
+  agentDeck: [makeCard("d1"), makeCard("d2"), makeCard("d3")],
+  boardShapes: { agent: [makeShape("s1")], opponent: [makeShape("s2")] },
+  opponentHand: [makeCard("o1"), makeCard("o2"), makeCard("o3")],
+  opponentDeckSize: 10,
+};
+
+describe("filterGameState", () => {
+  it("fair: shows agent hand, hides deck contents, hides opponent hand", () => {
+    const result = filterGameState(rawState, "fair");
+    expect(result.agentHand).toEqual(rawState.agentHand);
+    expect(result.agentDeckSize).toBe(3);
+    expect(result.agentDeckContents).toBeUndefined();
+    expect(result.opponentHandCount).toBe(3);
+    expect(result.opponentHandContents).toBeUndefined();
+    expect(result.boardShapes).toEqual(rawState.boardShapes);
+  });
+
+  it("full: shows everything including deck contents and opponent hand", () => {
+    const result = filterGameState(rawState, "full");
+    expect(result.agentHand).toEqual(rawState.agentHand);
+    expect(result.agentDeckSize).toBe(3);
+    expect(result.agentDeckContents).toEqual(rawState.agentDeck);
+    expect(result.opponentHandCount).toBe(3);
+    expect(result.opponentHandContents).toEqual(rawState.opponentHand);
+  });
+
+  it("board shapes are always fully visible", () => {
+    const fair = filterGameState(rawState, "fair");
+    const full = filterGameState(rawState, "full");
+    expect(fair.boardShapes).toEqual(full.boardShapes);
+  });
+});

--- a/maginet-agent/src/__tests__/visibility.test.ts
+++ b/maginet-agent/src/__tests__/visibility.test.ts
@@ -16,6 +16,7 @@ const rawState: RawGameState = {
   agentDeck: [makeCard("d1"), makeCard("d2"), makeCard("d3")],
   boardShapes: { agent: [makeShape("s1")], opponent: [makeShape("s2")] },
   opponentHand: [makeCard("o1"), makeCard("o2"), makeCard("o3")],
+  opponentHandCount: 3,
   opponentDeckSize: 10,
 };
 

--- a/maginet-agent/src/index.ts
+++ b/maginet-agent/src/index.ts
@@ -35,15 +35,74 @@ async function main() {
   console.error(`[maginet-agent] WebSocket server listening on port ${assignedPort}`);
   console.error(`[maginet-agent] Visibility: ${visibility}`);
 
+  // Send current shapes to the browser when it connects
+  wsServer.onConnect(() => {
+    const currentShapes = gameState.getAgentShapes();
+    if (currentShapes.length > 0) {
+      wsServer.send({
+        type: "sync:channel-snapshot",
+        payload: {
+          channel: "shapes:v1",
+          snapshot: {
+            agent: currentShapes,
+          },
+        },
+        meta: {
+          version: 1,
+          roomId: "maginet-agent",
+          from: "agent",
+          msgId: `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+          ts: Date.now(),
+        },
+      });
+    }
+  });
+
+  // Broadcast agent shape changes to the browser via sync protocol
+  gameState.subscribeShapes((nextShapes) => {
+    wsServer.send({
+      type: "sync:channel-snapshot",
+      payload: {
+        channel: "shapes:v1",
+        snapshot: {
+          agent: nextShapes,
+        },
+      },
+      meta: {
+        version: 1,
+        roomId: "maginet-agent",
+        from: "agent",
+        msgId: `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+        ts: Date.now(),
+      },
+    });
+  });
+
   // Listen for sync messages from the browser
   wsServer.onMessage((message) => {
-    if (message.type === "sync:channel-snapshot" || message.type === "sync:channel-patch") {
-      const payload = message.payload as Record<string, unknown>;
-      if (payload && typeof payload === "object") {
-        for (const [peerId, shapes] of Object.entries(payload)) {
+    if (message.type === "sync:channel-snapshot") {
+      const payload = message.payload as { channel?: string; snapshot?: Record<string, unknown> };
+      const snapshot = payload?.snapshot;
+      if (snapshot && typeof snapshot === "object") {
+        for (const [peerId, shapes] of Object.entries(snapshot)) {
           if (Array.isArray(shapes)) {
             remoteShapes[peerId] = shapes as Shape[];
           }
+        }
+      }
+    } else if (message.type === "sync:channel-patch") {
+      const payload = message.payload as { channel?: string; patch?: { peerPatches?: Array<{ peerId: string; patch: { upserts?: Shape[]; removedIds?: string[] } }>; removedPeerIds?: string[] } };
+      if (payload?.patch?.peerPatches) {
+        for (const { peerId, patch } of payload.patch.peerPatches) {
+          const current = remoteShapes[peerId] ?? [];
+          const byId = new Map(current.map((s) => [s.id, s]));
+          if (patch.removedIds) {
+            for (const id of patch.removedIds) byId.delete(id);
+          }
+          if (patch.upserts) {
+            for (const shape of patch.upserts) byId.set(shape.id, shape);
+          }
+          remoteShapes[peerId] = Array.from(byId.values());
         }
       }
     }

--- a/maginet-agent/src/index.ts
+++ b/maginet-agent/src/index.ts
@@ -1,0 +1,195 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { AgentWebSocketServer } from "./server.js";
+import { AgentGameState, type Shape } from "./state.js";
+import { createToolHandlers, TOOL_DEFINITIONS } from "./mcp.js";
+import { loadDeckFromList } from "./scryfall.js";
+import type { Visibility } from "./visibility.js";
+
+function parseArgs(argv: string[]): { port: number; visibility: Visibility } {
+  let port = 3210;
+  let visibility: Visibility = "fair";
+
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--port" && argv[i + 1]) {
+      port = parseInt(argv[i + 1], 10);
+    }
+    if (argv[i] === "--visibility" && argv[i + 1]) {
+      visibility = argv[i + 1] as Visibility;
+    }
+  }
+
+  return { port, visibility };
+}
+
+async function main() {
+  const { port, visibility } = parseArgs(process.argv.slice(2));
+
+  const gameState = new AgentGameState();
+  const wsServer = new AgentWebSocketServer({ port });
+  const remoteShapes: Record<string, Shape[]> = {};
+  let remoteCardState: { cards: number; deck: number } | null = null;
+
+  const assignedPort = await wsServer.start();
+  console.error(`[maginet-agent] WebSocket server listening on port ${assignedPort}`);
+  console.error(`[maginet-agent] Visibility: ${visibility}`);
+
+  // Listen for sync messages from the browser
+  wsServer.onMessage((message) => {
+    if (message.type === "sync:channel-snapshot" || message.type === "sync:channel-patch") {
+      const payload = message.payload as Record<string, unknown>;
+      if (payload && typeof payload === "object") {
+        for (const [peerId, shapes] of Object.entries(payload)) {
+          if (Array.isArray(shapes)) {
+            remoteShapes[peerId] = shapes as Shape[];
+          }
+        }
+      }
+    }
+
+    if (message.type === "action-log") {
+      const payload = message.payload as Record<string, unknown>;
+      console.error(`[maginet-agent] Action: ${JSON.stringify(payload)}`);
+    }
+
+    if (message.type === "card-state-sync") {
+      const payload = message.payload as { cards: number; deck: number };
+      remoteCardState = payload;
+    }
+  });
+
+  // Create MCP server
+  const mcp = new McpServer({
+    name: "maginet-agent",
+    version: "0.1.0",
+  });
+
+  // Mutable context — handlers read current values of remoteShapes/remoteCardState
+  const toolCtx = {
+    state: gameState,
+    server: wsServer,
+    visibility,
+    remoteShapes,
+    get remoteCardState() {
+      return remoteCardState;
+    },
+  };
+
+  const handlers = createToolHandlers(toolCtx);
+
+  // Register loadDeck separately (async Scryfall fetch)
+  mcp.tool(
+    "loadDeck",
+    "Load a deck from a deck list string (MTGO format). Fetches card images from Scryfall.",
+    { deckList: z.string().describe("Deck list in MTGO format, e.g. '4 Lightning Bolt'") },
+    async (args) => {
+      try {
+        const cards = await loadDeckFromList(args.deckList);
+        gameState.initializeDeck(cards);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: true, deckSize: cards.length }) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `Failed to load deck: ${e}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Register loadSnapshot
+  mcp.tool(
+    "loadSnapshot",
+    "Load a debug snapshot JSON to resume a game state.",
+    { snapshot: z.string().describe("JSON string of a Maginet debug snapshot") },
+    async (args) => {
+      try {
+        const snap = JSON.parse(args.snapshot) as {
+          cardState?: { deck?: { id: string; src: string[] }[]; cards?: { id: string; src: string[] }[] };
+          shapes?: Shape[];
+        };
+        if (snap.cardState) {
+          gameState.initializeDeck(snap.cardState.deck ?? []);
+          if (snap.cardState.cards) {
+            gameState.sendToHand(snap.cardState.cards);
+          }
+        }
+        if (snap.shapes && Array.isArray(snap.shapes)) {
+          for (const shape of snap.shapes) {
+            gameState.addAgentShape(shape);
+          }
+        }
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: true }) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text" as const, text: `Failed to load snapshot: ${e}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Register remaining tools dynamically
+  for (const def of TOOL_DEFINITIONS) {
+    if (def.name === "loadDeck" || def.name === "loadSnapshot") continue; // already registered
+
+    const handler = handlers[def.name as keyof typeof handlers];
+    if (!handler) continue;
+
+    // Build zod schema from inputSchema
+    const props =
+      (def.inputSchema as { properties?: Record<string, unknown>; required?: string[] }).properties ?? {};
+    const required = (def.inputSchema as { required?: string[] }).required ?? [];
+    const zodShape: Record<string, z.ZodType> = {};
+
+    for (const [key, schema] of Object.entries(props)) {
+      const s = schema as { type: string };
+      let zodType: z.ZodType;
+      if (s.type === "string") {
+        zodType = z.string();
+      } else if (s.type === "boolean") {
+        zodType = z.boolean();
+      } else if (s.type === "number") {
+        zodType = z.number();
+      } else if (s.type === "array") {
+        zodType = z.array(z.number());
+      } else if (s.type === "object") {
+        zodType = z.record(z.string(), z.unknown());
+      } else {
+        zodType = z.unknown();
+      }
+      if (!required.includes(key)) {
+        zodType = zodType.optional();
+      }
+      zodShape[key] = zodType;
+    }
+
+    // Capture handler in closure to avoid loop variable issues
+    const capturedHandler = handler;
+
+    if (Object.keys(zodShape).length === 0) {
+      // No-parameter tool
+      mcp.tool(def.name, def.description, async () => {
+        return capturedHandler({});
+      });
+    } else {
+      mcp.tool(def.name, def.description, zodShape, async (args) => {
+        return capturedHandler(args as Record<string, unknown>);
+      });
+    }
+  }
+
+  // Start MCP over stdio
+  const transport = new StdioServerTransport();
+  await mcp.connect(transport);
+  console.error("[maginet-agent] MCP server running on stdio");
+}
+
+main().catch((error: unknown) => {
+  console.error("[maginet-agent] Fatal error:", error);
+  process.exit(1);
+});

--- a/maginet-agent/src/index.ts
+++ b/maginet-agent/src/index.ts
@@ -33,11 +33,11 @@ async function main() {
   const gameState = new AgentGameState();
   const wsServer = new AgentWebSocketServer({ port });
   const remoteShapes: Record<string, Shape[]> = {};
-  let remoteCardState: { cards: number; deck: number } | null = null;
+  let remoteCardState: { cards: number; deck: number; hand: Array<{ id: string; src: string[] }> } | null = null;
   const MAX_ACTION_LOG = 200;
   const actionLog: Array<{ timestamp: number; action: string; playerId?: string; playerName?: string; cardsInHand?: number; cardNames?: string[] }> = [];
   const pushActionLog = (entry: (typeof actionLog)[number]) => {
-    pushActionLog(entry);
+    actionLog.push(entry);
     if (actionLog.length > MAX_ACTION_LOG) actionLog.splice(0, actionLog.length - MAX_ACTION_LOG);
   };
 
@@ -173,8 +173,8 @@ async function main() {
     }
 
     if (message.type === "card-state-sync") {
-      const payload = message.payload as { cards: number; deck: number };
-      remoteCardState = payload;
+      const payload = message.payload as { cards: number; deck: number; hand?: Array<{ id: string; src: string[] }> };
+      remoteCardState = { cards: payload.cards, deck: payload.deck, hand: payload.hand ?? [] };
     }
   });
 

--- a/maginet-agent/src/index.ts
+++ b/maginet-agent/src/index.ts
@@ -30,6 +30,7 @@ async function main() {
   const wsServer = new AgentWebSocketServer({ port });
   const remoteShapes: Record<string, Shape[]> = {};
   let remoteCardState: { cards: number; deck: number } | null = null;
+  const actionLog: Array<{ timestamp: number; action: string; playerId?: string; playerName?: string; cardsInHand?: number }> = [];
 
   const assignedPort = await wsServer.start();
   console.error(`[maginet-agent] WebSocket server listening on port ${assignedPort}`);
@@ -108,8 +109,30 @@ async function main() {
     }
 
     if (message.type === "action-log") {
-      const payload = message.payload as Record<string, unknown>;
-      console.error(`[maginet-agent] Action: ${JSON.stringify(payload)}`);
+      const payload = message.payload as { action?: string; playerId?: string; playerName?: string; cardsInHand?: number; timestamp?: number };
+      actionLog.push({
+        timestamp: payload.timestamp ?? Date.now(),
+        action: payload.action ?? "unknown",
+        playerId: payload.playerId,
+        playerName: payload.playerName,
+        cardsInHand: payload.cardsInHand,
+      });
+      console.error(`[maginet-agent] Action: ${payload.playerName ?? payload.playerId}: ${payload.action}`);
+    }
+
+    if (message.type === "action-log-snapshot") {
+      const payload = message.payload as { entries?: Array<{ action?: string; playerId?: string; playerName?: string; cardsInHand?: number; timestamp?: number }> };
+      if (payload.entries) {
+        for (const entry of payload.entries) {
+          actionLog.push({
+            timestamp: entry.timestamp ?? Date.now(),
+            action: entry.action ?? "unknown",
+            playerId: entry.playerId,
+            playerName: entry.playerName,
+            cardsInHand: entry.cardsInHand,
+          });
+        }
+      }
     }
 
     if (message.type === "card-state-sync") {
@@ -130,6 +153,7 @@ async function main() {
     server: wsServer,
     visibility,
     remoteShapes,
+    actionLog,
     get remoteCardState() {
       return remoteCardState;
     },

--- a/maginet-agent/src/index.ts
+++ b/maginet-agent/src/index.ts
@@ -106,8 +106,14 @@ async function main() {
     }
   };
 
+  // Debug: store recent raw message types
+  const debugMessages: Array<{ ts: number; type: string }> = [];
+
   // Listen for sync messages from the browser
   wsServer.onMessage((message) => {
+    debugMessages.push({ ts: Date.now(), type: message.type });
+    if (debugMessages.length > 50) debugMessages.shift();
+    console.error(`[maginet-agent] WS message: type=${message.type}`);
     if (message.type === "sync:channel-snapshot") {
       const payload = message.payload as { channel?: string; snapshot?: Record<string, unknown> };
       const snapshot = payload?.snapshot;
@@ -252,6 +258,17 @@ async function main() {
           isError: true,
         };
       }
+    }
+  );
+
+  // Debug tool to check what messages the agent receives
+  mcp.tool(
+    "debugMessages",
+    "Show recent WebSocket messages received (for debugging sync issues).",
+    async () => {
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify({ connected: wsServer.isConnected(), messages: debugMessages }, null, 2) }],
+      };
     }
   );
 

--- a/maginet-agent/src/index.ts
+++ b/maginet-agent/src/index.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { AgentWebSocketServer } from "./server.js";
 import { AgentGameState, type Shape } from "./state.js";
 import { createToolHandlers, TOOL_DEFINITIONS } from "./mcp.js";
-import { loadDeckFromList } from "./scryfall.js";
+import { loadDeckFromList, fetchCardMetaByImageUrl } from "./scryfall.js";
 import type { Visibility } from "./visibility.js";
 
 function parseArgs(argv: string[]): { port: number; visibility: Visibility } {
@@ -16,7 +16,11 @@ function parseArgs(argv: string[]): { port: number; visibility: Visibility } {
       port = parseInt(argv[i + 1], 10);
     }
     if (argv[i] === "--visibility" && argv[i + 1]) {
-      visibility = argv[i + 1] as Visibility;
+      const v = argv[i + 1];
+      if (v !== "fair" && v !== "full") {
+        throw new Error(`--visibility must be "fair" or "full", got "${v}"`);
+      }
+      visibility = v;
     }
   }
 
@@ -30,7 +34,12 @@ async function main() {
   const wsServer = new AgentWebSocketServer({ port });
   const remoteShapes: Record<string, Shape[]> = {};
   let remoteCardState: { cards: number; deck: number } | null = null;
-  const actionLog: Array<{ timestamp: number; action: string; playerId?: string; playerName?: string; cardsInHand?: number }> = [];
+  const MAX_ACTION_LOG = 200;
+  const actionLog: Array<{ timestamp: number; action: string; playerId?: string; playerName?: string; cardsInHand?: number; cardNames?: string[] }> = [];
+  const pushActionLog = (entry: (typeof actionLog)[number]) => {
+    pushActionLog(entry);
+    if (actionLog.length > MAX_ACTION_LOG) actionLog.splice(0, actionLog.length - MAX_ACTION_LOG);
+  };
 
   const assignedPort = await wsServer.start();
   console.error(`[maginet-agent] WebSocket server listening on port ${assignedPort}`);
@@ -79,6 +88,24 @@ async function main() {
     });
   });
 
+  // Auto-fetch Scryfall metadata for unknown card images
+  const pendingLookups = new Set<string>();
+  const resolveUnknownCards = (shapes: Shape[]) => {
+    for (const shape of shapes) {
+      if (shape.type !== "image" || !shape.src?.length) continue;
+      const url = shape.src[0];
+      if (gameState.lookupCardMeta(url) || pendingLookups.has(url)) continue;
+      pendingLookups.add(url);
+      fetchCardMetaByImageUrl(url).then((result) => {
+        pendingLookups.delete(url);
+        if (result) {
+          gameState.registerCardMeta(result.imageUrl, result.meta);
+          console.error(`[maginet-agent] Resolved: ${result.meta.name}`);
+        }
+      }).catch(() => { pendingLookups.delete(url); });
+    }
+  };
+
   // Listen for sync messages from the browser
   wsServer.onMessage((message) => {
     if (message.type === "sync:channel-snapshot") {
@@ -88,6 +115,7 @@ async function main() {
         for (const [peerId, shapes] of Object.entries(snapshot)) {
           if (Array.isArray(shapes)) {
             remoteShapes[peerId] = shapes as Shape[];
+            resolveUnknownCards(shapes as Shape[]);
           }
         }
       }
@@ -103,28 +131,37 @@ async function main() {
           if (patch.upserts) {
             for (const shape of patch.upserts) byId.set(shape.id, shape);
           }
-          remoteShapes[peerId] = Array.from(byId.values());
+          const updated = Array.from(byId.values());
+          remoteShapes[peerId] = updated;
+          resolveUnknownCards(updated);
         }
       }
     }
 
     if (message.type === "action-log") {
-      const payload = message.payload as { action?: string; playerId?: string; playerName?: string; cardsInHand?: number; timestamp?: number };
-      actionLog.push({
+      const payload = message.payload as { action?: string; playerId?: string; playerName?: string; cardsInHand?: number; timestamp?: number; cardSrcs?: string[][] };
+      // Resolve card names from image URLs
+      const cardNames = payload.cardSrcs?.map((srcs) => {
+        const meta = gameState.lookupCardMeta(srcs[0]);
+        return meta?.name ?? srcs[0];
+      });
+      pushActionLog({
         timestamp: payload.timestamp ?? Date.now(),
         action: payload.action ?? "unknown",
         playerId: payload.playerId,
         playerName: payload.playerName,
         cardsInHand: payload.cardsInHand,
+        cardNames,
       });
-      console.error(`[maginet-agent] Action: ${payload.playerName ?? payload.playerId}: ${payload.action}`);
+      const nameStr = cardNames?.length ? ` (${cardNames.join(", ")})` : "";
+      console.error(`[maginet-agent] Action: ${payload.playerName ?? payload.playerId}: ${payload.action}${nameStr}`);
     }
 
     if (message.type === "action-log-snapshot") {
       const payload = message.payload as { entries?: Array<{ action?: string; playerId?: string; playerName?: string; cardsInHand?: number; timestamp?: number }> };
       if (payload.entries) {
         for (const entry of payload.entries) {
-          actionLog.push({
+          pushActionLog({
             timestamp: entry.timestamp ?? Date.now(),
             action: entry.action ?? "unknown",
             playerId: entry.playerId,
@@ -193,6 +230,8 @@ async function main() {
           cardState?: { deck?: { id: string; src: string[] }[]; cards?: { id: string; src: string[] }[] };
           shapes?: Shape[];
         };
+        // Clear existing state before loading snapshot
+        gameState.clearAgentShapes();
         if (snap.cardState) {
           gameState.initializeDeck(snap.cardState.deck ?? []);
           if (snap.cardState.cards) {

--- a/maginet-agent/src/mcp.ts
+++ b/maginet-agent/src/mcp.ts
@@ -2,12 +2,21 @@ import type { AgentGameState, Shape, Counter, Card } from "./state.js";
 import type { AgentWebSocketServer } from "./server.js";
 import { type Visibility, filterGameState } from "./visibility.js";
 
+export interface ActionLogEntry {
+  timestamp: number;
+  action: string;
+  playerId?: string;
+  playerName?: string;
+  cardsInHand?: number;
+}
+
 export interface ToolContext {
   state: AgentGameState;
   server: AgentWebSocketServer;
   visibility: Visibility;
   remoteShapes: Record<string, Shape[]>;
   remoteCardState: { cards: number; deck: number } | null;
+  actionLog: ActionLogEntry[];
 }
 
 type ToolResult = {
@@ -250,6 +259,12 @@ export function createToolHandlers(ctx: ToolContext) {
       return ok({ shapeId, text });
     },
 
+    async getActionLog(args: Record<string, unknown>): Promise<ToolResult> {
+      const limit = (args.limit as number | undefined) ?? 20;
+      const entries = ctx.actionLog.slice(-limit);
+      return ok(entries);
+    },
+
     async transformCard(args: Record<string, unknown>): Promise<ToolResult> {
       const shapeId = args.shapeId as string;
       const shape = state.findAgentShape(shapeId);
@@ -382,6 +397,16 @@ export const TOOL_DEFINITIONS = [
         label: { type: "string" },
       },
       required: ["shapeId", "label"],
+    },
+  },
+  {
+    name: "getActionLog",
+    description: "Get recent game actions from the opponent (draws, plays, shuffles, etc).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: { type: "number" },
+      },
     },
   },
   {

--- a/maginet-agent/src/mcp.ts
+++ b/maginet-agent/src/mcp.ts
@@ -151,9 +151,8 @@ export function createToolHandlers(ctx: ToolContext) {
 
     async untapAll(_: Record<string, unknown>): Promise<ToolResult> {
       const tapped = state.getAgentShapes().filter((s) => s.rotation && s.rotation !== 0);
-      for (const shape of tapped) {
-        state.updateAgentShape(shape.id, { rotation: 0 });
-      }
+      const updates = new Map(tapped.map((s) => [s.id, { rotation: 0 }]));
+      state.updateAgentShapes(updates);
       return ok({ message: `Untapped ${tapped.length} card(s).` });
     },
 
@@ -164,9 +163,10 @@ export function createToolHandlers(ctx: ToolContext) {
         return err(`Shape "${shapeId}" not found.`);
       }
       state.removeAgentShape(shapeId);
-      const card = { id: generateId(), src: shape.src ?? [] };
+      const meta = state.lookupShapeMeta(shape);
+      const card = { id: generateId(), src: shape.src ?? [], ...(meta ? { meta } : {}) };
       state.sendToHand([card]);
-      return ok({ message: "Card returned to hand.", card });
+      return ok({ message: "Card returned to hand.", card: { ...card, name: meta?.name } });
     },
 
     async sendToDeck(args: Record<string, unknown>): Promise<ToolResult> {
@@ -177,9 +177,21 @@ export function createToolHandlers(ctx: ToolContext) {
         return err(`Shape "${shapeId}" not found.`);
       }
       state.removeAgentShape(shapeId);
-      const card = { id: generateId(), src: shape.src ?? [] };
+      const meta = state.lookupShapeMeta(shape);
+      const card = { id: generateId(), src: shape.src ?? [], ...(meta ? { meta } : {}) };
       state.sendToDeck([card], position);
       return ok({ message: `Card sent to ${position} of deck.`, deckSize: state.getDeckSize() });
+    },
+
+    async removeShape(args: Record<string, unknown>): Promise<ToolResult> {
+      const shapeId = args.shapeId as string;
+      const shape = state.findAgentShape(shapeId);
+      if (!shape) {
+        return err(`Shape "${shapeId}" not found.`);
+      }
+      state.removeAgentShape(shapeId);
+      const meta = state.lookupShapeMeta(shape);
+      return ok({ message: "Shape removed.", shapeId, cardName: meta?.name });
     },
 
     async shuffleDeck(_: Record<string, unknown>): Promise<ToolResult> {
@@ -286,6 +298,18 @@ export function createToolHandlers(ctx: ToolContext) {
       };
       state.addAgentShape(shape);
       return ok({ message: "Rectangle placed.", shape });
+    },
+
+    async undo(_: Record<string, unknown>): Promise<ToolResult> {
+      const success = state.undo();
+      if (!success) return err("Nothing to undo.");
+      return ok({ message: "Undone." });
+    },
+
+    async redo(_: Record<string, unknown>): Promise<ToolResult> {
+      const success = state.redo();
+      if (!success) return err("Nothing to redo.");
+      return ok({ message: "Redone." });
     },
 
     async getActionLog(args: Record<string, unknown>): Promise<ToolResult> {
@@ -427,6 +451,25 @@ export const TOOL_DEFINITIONS = [
       },
       required: ["shapeId", "label"],
     },
+  },
+  {
+    name: "removeShape",
+    description: "Remove a shape from the board (e.g. destroy a token, remove resolved spell).",
+    inputSchema: {
+      type: "object",
+      properties: { shapeId: { type: "string" } },
+      required: ["shapeId"],
+    },
+  },
+  {
+    name: "undo",
+    description: "Undo the last game action (draw, play, shape change, etc).",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "redo",
+    description: "Redo a previously undone action.",
+    inputSchema: { type: "object", properties: {} },
   },
   {
     name: "moveShape",

--- a/maginet-agent/src/mcp.ts
+++ b/maginet-agent/src/mcp.ts
@@ -16,7 +16,7 @@ export interface ToolContext {
   server: AgentWebSocketServer;
   visibility: Visibility;
   remoteShapes: Record<string, Shape[]>;
-  remoteCardState: { cards: number; deck: number } | null;
+  remoteCardState: { cards: number; deck: number; hand: Array<{ id: string; src: string[] }> } | null;
   actionLog: ActionLogEntry[];
 }
 
@@ -34,7 +34,7 @@ function err(message: string): ToolResult {
 }
 
 function generateId(): string {
-  return Math.random().toString(36).substr(2, 9);
+  return Math.random().toString(36).slice(2, 11);
 }
 
 export function createToolHandlers(ctx: ToolContext) {
@@ -49,9 +49,11 @@ export function createToolHandlers(ctx: ToolContext) {
           agent: state.getAgentShapes(),
           ...ctx.remoteShapes,
         },
-        opponentHand: ctx.remoteCardState
-          ? ([] as { id: string; src: string[] }[])
-          : [],
+        opponentHand: (ctx.remoteCardState?.hand ?? []).map((c) => {
+          const meta = state.lookupCardMeta(c.src[0]);
+          return { ...c, name: meta?.name, typeLine: meta?.typeLine, oracleText: meta?.oracleText, manaCost: meta?.manaCost, power: meta?.power, toughness: meta?.toughness };
+        }),
+        opponentHandCount: ctx.remoteCardState?.cards ?? 0,
         opponentDeckSize: ctx.remoteCardState?.deck ?? 0,
       };
       const filtered = filterGameState(raw, ctx.visibility);

--- a/maginet-agent/src/mcp.ts
+++ b/maginet-agent/src/mcp.ts
@@ -8,6 +8,7 @@ export interface ActionLogEntry {
   playerId?: string;
   playerName?: string;
   cardsInHand?: number;
+  cardNames?: string[];
 }
 
 export interface ToolContext {
@@ -259,6 +260,34 @@ export function createToolHandlers(ctx: ToolContext) {
       return ok({ shapeId, text });
     },
 
+    async moveShape(args: Record<string, unknown>): Promise<ToolResult> {
+      const shapeId = args.shapeId as string;
+      const position = args.position as [number, number];
+      const shape = state.findAgentShape(shapeId);
+      if (!shape) return err(`Shape "${shapeId}" not found.`);
+      state.updateAgentShape(shapeId, { point: position });
+      return ok({ shapeId, point: position });
+    },
+
+    async placeRect(args: Record<string, unknown>): Promise<ToolResult> {
+      const position = args.position as [number, number] | undefined;
+      const size = args.size as [number, number] | undefined;
+      const color = (args.color as string | undefined) ?? "#555555";
+
+      const shape: Shape = {
+        id: generateId(),
+        point: position ?? [0, 0],
+        size: size ?? [200, 150],
+        type: "rectangle",
+        color,
+        srcIndex: 0,
+        rotation: 0,
+        isFlipped: false,
+      };
+      state.addAgentShape(shape);
+      return ok({ message: "Rectangle placed.", shape });
+    },
+
     async getActionLog(args: Record<string, unknown>): Promise<ToolResult> {
       const limit = (args.limit as number | undefined) ?? 20;
       const entries = ctx.actionLog.slice(-limit);
@@ -397,6 +426,30 @@ export const TOOL_DEFINITIONS = [
         label: { type: "string" },
       },
       required: ["shapeId", "label"],
+    },
+  },
+  {
+    name: "moveShape",
+    description: "Move a shape to a new position on the board.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        shapeId: { type: "string" },
+        position: { type: "array", items: { type: "number" } },
+      },
+      required: ["shapeId", "position"],
+    },
+  },
+  {
+    name: "placeRect",
+    description: "Place a rectangle on the board (e.g. for zones like graveyard, exile).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        position: { type: "array", items: { type: "number" } },
+        size: { type: "array", items: { type: "number" } },
+        color: { type: "string" },
+      },
     },
   },
   {

--- a/maginet-agent/src/mcp.ts
+++ b/maginet-agent/src/mcp.ts
@@ -31,7 +31,7 @@ export function createToolHandlers(ctx: ToolContext) {
   const { state } = ctx;
 
   return {
-    async getGameState(_args: Record<string, unknown>): Promise<ToolResult> {
+    async getGameState(_: Record<string, unknown>): Promise<ToolResult> {
       const raw = {
         agentHand: state.getHand(),
         agentDeck: state.getDeckContents(),
@@ -48,11 +48,11 @@ export function createToolHandlers(ctx: ToolContext) {
       return ok(filtered);
     },
 
-    async getHand(_args: Record<string, unknown>): Promise<ToolResult> {
+    async getHand(_: Record<string, unknown>): Promise<ToolResult> {
       return ok(state.getHand());
     },
 
-    async getBoardState(_args: Record<string, unknown>): Promise<ToolResult> {
+    async getBoardState(_: Record<string, unknown>): Promise<ToolResult> {
       const board: Record<string, Shape[]> = {
         agent: state.getAgentShapes(),
         ...ctx.remoteShapes,
@@ -60,7 +60,7 @@ export function createToolHandlers(ctx: ToolContext) {
       return ok(board);
     },
 
-    async getDeckInfo(_args: Record<string, unknown>): Promise<ToolResult> {
+    async getDeckInfo(_: Record<string, unknown>): Promise<ToolResult> {
       const info: { size: number; contents?: { id: string; src: string[] }[] } = {
         size: state.getDeckSize(),
       };
@@ -70,7 +70,7 @@ export function createToolHandlers(ctx: ToolContext) {
       return ok(info);
     },
 
-    async drawCard(_args: Record<string, unknown>): Promise<ToolResult> {
+    async drawCard(_: Record<string, unknown>): Promise<ToolResult> {
       const card = state.drawCard();
       if (!card) {
         return err("Deck is empty — cannot draw a card.");
@@ -78,7 +78,7 @@ export function createToolHandlers(ctx: ToolContext) {
       return ok(card);
     },
 
-    async mulligan(_args: Record<string, unknown>): Promise<ToolResult> {
+    async mulligan(_: Record<string, unknown>): Promise<ToolResult> {
       state.mulligan();
       return ok({ message: "Hand shuffled back into deck.", deckSize: state.getDeckSize() });
     },
@@ -124,7 +124,7 @@ export function createToolHandlers(ctx: ToolContext) {
       return ok({ shapeId, rotation: newRotation });
     },
 
-    async untapAll(_args: Record<string, unknown>): Promise<ToolResult> {
+    async untapAll(_: Record<string, unknown>): Promise<ToolResult> {
       const tapped = state.getAgentShapes().filter((s) => s.rotation && s.rotation !== 0);
       for (const shape of tapped) {
         state.updateAgentShape(shape.id, { rotation: 0 });
@@ -157,7 +157,7 @@ export function createToolHandlers(ctx: ToolContext) {
       return ok({ message: `Card sent to ${position} of deck.`, deckSize: state.getDeckSize() });
     },
 
-    async shuffleDeck(_args: Record<string, unknown>): Promise<ToolResult> {
+    async shuffleDeck(_: Record<string, unknown>): Promise<ToolResult> {
       state.shuffleDeck();
       return ok({ message: "Deck shuffled.", deckSize: state.getDeckSize() });
     },

--- a/maginet-agent/src/mcp.ts
+++ b/maginet-agent/src/mcp.ts
@@ -1,4 +1,4 @@
-import type { AgentGameState, Shape, Counter } from "./state.js";
+import type { AgentGameState, Shape, Counter, Card } from "./state.js";
 import type { AgentWebSocketServer } from "./server.js";
 import { type Visibility, filterGameState } from "./visibility.js";
 
@@ -49,14 +49,29 @@ export function createToolHandlers(ctx: ToolContext) {
     },
 
     async getHand(_: Record<string, unknown>): Promise<ToolResult> {
-      return ok(state.getHand());
+      const hand = state.getHand().map((card) => ({
+        ...card,
+        name: card.meta?.name,
+        manaCost: card.meta?.manaCost,
+        typeLine: card.meta?.typeLine,
+        oracleText: card.meta?.oracleText,
+        power: card.meta?.power,
+        toughness: card.meta?.toughness,
+      }));
+      return ok(hand);
     },
 
     async getBoardState(_: Record<string, unknown>): Promise<ToolResult> {
-      const board: Record<string, Shape[]> = {
-        agent: state.getAgentShapes(),
-        ...ctx.remoteShapes,
+      const enrichShape = (shape: Shape) => {
+        const meta = state.lookupShapeMeta(shape);
+        return meta ? { ...shape, cardName: meta.name, typeLine: meta.typeLine, oracleText: meta.oracleText, manaCost: meta.manaCost, power: meta.power, toughness: meta.toughness } : shape;
       };
+      const board: Record<string, (Shape & { cardName?: string; typeLine?: string; oracleText?: string; manaCost?: string; power?: string; toughness?: string })[]> = {
+        agent: state.getAgentShapes().map(enrichShape),
+      };
+      for (const [peerId, shapes] of Object.entries(ctx.remoteShapes)) {
+        board[peerId] = shapes.map(enrichShape);
+      }
       return ok(board);
     },
 
@@ -200,6 +215,41 @@ export function createToolHandlers(ctx: ToolContext) {
       return ok({ shapeId, isFlipped: newFlipped });
     },
 
+    async placeText(args: Record<string, unknown>): Promise<ToolResult> {
+      const text = args.text as string;
+      const position = args.position as [number, number] | undefined;
+      const fontSize = (args.fontSize as number | undefined) ?? 24;
+      const color = (args.color as string | undefined) ?? "#ffffff";
+
+      const point = position ?? [100, 100];
+      const shape: Shape = {
+        id: generateId(),
+        point,
+        size: [200, 50],
+        type: "text",
+        text,
+        fontSize,
+        color,
+        srcIndex: 0,
+        rotation: 0,
+        isFlipped: false,
+      };
+
+      state.addAgentShape(shape);
+      return ok({ message: "Text placed.", shape });
+    },
+
+    async updateText(args: Record<string, unknown>): Promise<ToolResult> {
+      const shapeId = args.shapeId as string;
+      const text = args.text as string;
+      const shape = state.findAgentShape(shapeId);
+      if (!shape) {
+        return err(`Shape "${shapeId}" not found.`);
+      }
+      state.updateAgentShape(shapeId, { text });
+      return ok({ shapeId, text });
+    },
+
     async transformCard(args: Record<string, unknown>): Promise<ToolResult> {
       const shapeId = args.shapeId as string;
       const shape = state.findAgentShape(shapeId);
@@ -332,6 +382,32 @@ export const TOOL_DEFINITIONS = [
         label: { type: "string" },
       },
       required: ["shapeId", "label"],
+    },
+  },
+  {
+    name: "placeText",
+    description: "Place a text label on the board (e.g. for HP counters, notes).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        text: { type: "string" },
+        position: { type: "array", items: { type: "number" } },
+        fontSize: { type: "number" },
+        color: { type: "string" },
+      },
+      required: ["text"],
+    },
+  },
+  {
+    name: "updateText",
+    description: "Update the text content of an existing text shape.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        shapeId: { type: "string" },
+        text: { type: "string" },
+      },
+      required: ["shapeId", "text"],
     },
   },
   {

--- a/maginet-agent/src/mcp.ts
+++ b/maginet-agent/src/mcp.ts
@@ -1,0 +1,355 @@
+import type { AgentGameState, Shape, Counter } from "./state.js";
+import type { AgentWebSocketServer } from "./server.js";
+import { type Visibility, filterGameState } from "./visibility.js";
+
+export interface ToolContext {
+  state: AgentGameState;
+  server: AgentWebSocketServer;
+  visibility: Visibility;
+  remoteShapes: Record<string, Shape[]>;
+  remoteCardState: { cards: number; deck: number } | null;
+}
+
+type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+function ok(data: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+}
+
+function err(message: string): ToolResult {
+  return { content: [{ type: "text", text: message }], isError: true };
+}
+
+function generateId(): string {
+  return Math.random().toString(36).substr(2, 9);
+}
+
+export function createToolHandlers(ctx: ToolContext) {
+  const { state } = ctx;
+
+  return {
+    async getGameState(_args: Record<string, unknown>): Promise<ToolResult> {
+      const raw = {
+        agentHand: state.getHand(),
+        agentDeck: state.getDeckContents(),
+        boardShapes: {
+          agent: state.getAgentShapes(),
+          ...ctx.remoteShapes,
+        },
+        opponentHand: ctx.remoteCardState
+          ? ([] as { id: string; src: string[] }[])
+          : [],
+        opponentDeckSize: ctx.remoteCardState?.deck ?? 0,
+      };
+      const filtered = filterGameState(raw, ctx.visibility);
+      return ok(filtered);
+    },
+
+    async getHand(_args: Record<string, unknown>): Promise<ToolResult> {
+      return ok(state.getHand());
+    },
+
+    async getBoardState(_args: Record<string, unknown>): Promise<ToolResult> {
+      const board: Record<string, Shape[]> = {
+        agent: state.getAgentShapes(),
+        ...ctx.remoteShapes,
+      };
+      return ok(board);
+    },
+
+    async getDeckInfo(_args: Record<string, unknown>): Promise<ToolResult> {
+      const info: { size: number; contents?: { id: string; src: string[] }[] } = {
+        size: state.getDeckSize(),
+      };
+      if (ctx.visibility === "full") {
+        info.contents = state.getDeckContents();
+      }
+      return ok(info);
+    },
+
+    async drawCard(_args: Record<string, unknown>): Promise<ToolResult> {
+      const card = state.drawCard();
+      if (!card) {
+        return err("Deck is empty — cannot draw a card.");
+      }
+      return ok(card);
+    },
+
+    async mulligan(_args: Record<string, unknown>): Promise<ToolResult> {
+      state.mulligan();
+      return ok({ message: "Hand shuffled back into deck.", deckSize: state.getDeckSize() });
+    },
+
+    async playCard(args: Record<string, unknown>): Promise<ToolResult> {
+      const cardId = args.cardId as string;
+      const position = args.position as [number, number] | undefined;
+      const faceDown = (args.faceDown as boolean | undefined) ?? false;
+
+      const card = state.playCard(cardId);
+      if (!card) {
+        return err(`Card "${cardId}" not found in hand.`);
+      }
+
+      const point = position ?? [
+        Math.floor(Math.random() * 400),
+        Math.floor(Math.random() * 400),
+      ];
+
+      const shape: Shape = {
+        id: generateId(),
+        point,
+        size: [100, 100],
+        type: "image",
+        src: card.src,
+        srcIndex: 0,
+        rotation: 0,
+        isFlipped: faceDown,
+      };
+
+      state.addAgentShape(shape);
+      return ok({ message: "Card played.", shape });
+    },
+
+    async tapCard(args: Record<string, unknown>): Promise<ToolResult> {
+      const shapeId = args.shapeId as string;
+      const shape = state.findAgentShape(shapeId);
+      if (!shape) {
+        return err(`Shape "${shapeId}" not found.`);
+      }
+      const newRotation = (shape.rotation ?? 0) === 0 ? 90 : 0;
+      state.updateAgentShape(shapeId, { rotation: newRotation });
+      return ok({ shapeId, rotation: newRotation });
+    },
+
+    async untapAll(_args: Record<string, unknown>): Promise<ToolResult> {
+      const tapped = state.getAgentShapes().filter((s) => s.rotation && s.rotation !== 0);
+      for (const shape of tapped) {
+        state.updateAgentShape(shape.id, { rotation: 0 });
+      }
+      return ok({ message: `Untapped ${tapped.length} card(s).` });
+    },
+
+    async sendToHand(args: Record<string, unknown>): Promise<ToolResult> {
+      const shapeId = args.shapeId as string;
+      const shape = state.findAgentShape(shapeId);
+      if (!shape) {
+        return err(`Shape "${shapeId}" not found.`);
+      }
+      state.removeAgentShape(shapeId);
+      const card = { id: generateId(), src: shape.src ?? [] };
+      state.sendToHand([card]);
+      return ok({ message: "Card returned to hand.", card });
+    },
+
+    async sendToDeck(args: Record<string, unknown>): Promise<ToolResult> {
+      const shapeId = args.shapeId as string;
+      const position = (args.position as "top" | "bottom") ?? "bottom";
+      const shape = state.findAgentShape(shapeId);
+      if (!shape) {
+        return err(`Shape "${shapeId}" not found.`);
+      }
+      state.removeAgentShape(shapeId);
+      const card = { id: generateId(), src: shape.src ?? [] };
+      state.sendToDeck([card], position);
+      return ok({ message: `Card sent to ${position} of deck.`, deckSize: state.getDeckSize() });
+    },
+
+    async shuffleDeck(_args: Record<string, unknown>): Promise<ToolResult> {
+      state.shuffleDeck();
+      return ok({ message: "Deck shuffled.", deckSize: state.getDeckSize() });
+    },
+
+    async addCounter(args: Record<string, unknown>): Promise<ToolResult> {
+      const shapeId = args.shapeId as string;
+      const counter = args.counter as Counter;
+      const shape = state.findAgentShape(shapeId);
+      if (!shape) {
+        return err(`Shape "${shapeId}" not found.`);
+      }
+      const existing = shape.counters ?? [];
+      const updated = existing.some((c) => c.label === counter.label)
+        ? existing.map((c) => (c.label === counter.label ? { ...c, ...counter } : c))
+        : [...existing, counter];
+      state.updateAgentShape(shapeId, { counters: updated });
+      return ok({ shapeId, counters: updated });
+    },
+
+    async removeCounter(args: Record<string, unknown>): Promise<ToolResult> {
+      const shapeId = args.shapeId as string;
+      const label = args.label as string;
+      const shape = state.findAgentShape(shapeId);
+      if (!shape) {
+        return err(`Shape "${shapeId}" not found.`);
+      }
+      const updated = (shape.counters ?? []).filter((c) => c.label !== label);
+      state.updateAgentShape(shapeId, { counters: updated });
+      return ok({ shapeId, counters: updated });
+    },
+
+    async flipCard(args: Record<string, unknown>): Promise<ToolResult> {
+      const shapeId = args.shapeId as string;
+      const shape = state.findAgentShape(shapeId);
+      if (!shape) {
+        return err(`Shape "${shapeId}" not found.`);
+      }
+      const newFlipped = !shape.isFlipped;
+      state.updateAgentShape(shapeId, { isFlipped: newFlipped });
+      return ok({ shapeId, isFlipped: newFlipped });
+    },
+
+    async transformCard(args: Record<string, unknown>): Promise<ToolResult> {
+      const shapeId = args.shapeId as string;
+      const shape = state.findAgentShape(shapeId);
+      if (!shape) {
+        return err(`Shape "${shapeId}" not found.`);
+      }
+      const srcLength = shape.src?.length ?? 1;
+      const newIndex = ((shape.srcIndex ?? 0) + 1) % srcLength;
+      state.updateAgentShape(shapeId, { srcIndex: newIndex });
+      return ok({ shapeId, srcIndex: newIndex });
+    },
+  };
+}
+
+export const TOOL_DEFINITIONS = [
+  {
+    name: "getGameState",
+    description:
+      "Get a full snapshot of the current game: your hand, deck size, board shapes, and opponent info.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "getHand",
+    description: "Get the cards currently in your hand.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "getBoardState",
+    description: "Get all shapes on the board, grouped by player.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "getDeckInfo",
+    description:
+      "Get deck size. In full visibility mode, also returns deck contents.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "drawCard",
+    description: "Draw the top card from your deck into your hand.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "mulligan",
+    description: "Shuffle your entire hand back into your deck.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "playCard",
+    description: "Play a card from your hand onto the board.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        cardId: { type: "string" },
+        position: { type: "array", items: { type: "number" } },
+        faceDown: { type: "boolean" },
+      },
+      required: ["cardId"],
+    },
+  },
+  {
+    name: "tapCard",
+    description: "Toggle tap/untap on a card.",
+    inputSchema: {
+      type: "object",
+      properties: { shapeId: { type: "string" } },
+      required: ["shapeId"],
+    },
+  },
+  {
+    name: "untapAll",
+    description: "Untap all your cards on the board.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "sendToHand",
+    description: "Return a card from the board back to your hand.",
+    inputSchema: {
+      type: "object",
+      properties: { shapeId: { type: "string" } },
+      required: ["shapeId"],
+    },
+  },
+  {
+    name: "sendToDeck",
+    description: "Return a card from the board to your deck.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        shapeId: { type: "string" },
+        position: { type: "string", enum: ["top", "bottom"] },
+      },
+      required: ["shapeId"],
+    },
+  },
+  {
+    name: "shuffleDeck",
+    description: "Shuffle your deck.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "addCounter",
+    description: "Add or update a counter on a card.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        shapeId: { type: "string" },
+        counter: {
+          type: "object",
+          properties: {
+            label: { type: "string" },
+            power: { type: "number" },
+            toughness: { type: "number" },
+            value: { type: "number" },
+            color: { type: "string" },
+          },
+          required: ["label"],
+        },
+      },
+      required: ["shapeId", "counter"],
+    },
+  },
+  {
+    name: "removeCounter",
+    description: "Remove a counter from a card by its label.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        shapeId: { type: "string" },
+        label: { type: "string" },
+      },
+      required: ["shapeId", "label"],
+    },
+  },
+  {
+    name: "flipCard",
+    description: "Toggle a card between face-up and face-down.",
+    inputSchema: {
+      type: "object",
+      properties: { shapeId: { type: "string" } },
+      required: ["shapeId"],
+    },
+  },
+  {
+    name: "transformCard",
+    description: "Switch a double-faced card to its other face.",
+    inputSchema: {
+      type: "object",
+      properties: { shapeId: { type: "string" } },
+      required: ["shapeId"],
+    },
+  },
+];

--- a/maginet-agent/src/scryfall.ts
+++ b/maginet-agent/src/scryfall.ts
@@ -13,6 +13,11 @@ interface ScryfallCard {
   image_uris?: ScryfallImageUris;
   card_faces?: ScryfallCardFace[];
   name: string;
+  type_line?: string;
+  oracle_text?: string;
+  mana_cost?: string;
+  power?: string;
+  toughness?: string;
 }
 
 interface ScryfallCollection {
@@ -20,9 +25,19 @@ interface ScryfallCollection {
   not_found: Array<{ name: string }>;
 }
 
+export interface CardMeta {
+  name: string;
+  typeLine?: string;
+  oracleText?: string;
+  manaCost?: string;
+  power?: string;
+  toughness?: string;
+}
+
 export interface DeckCard {
   id: string;
   src: string[];
+  meta?: CardMeta;
 }
 
 function generateId(): string {
@@ -63,13 +78,23 @@ async function fetchCards(names: string[]): Promise<ScryfallCollection> {
 }
 
 function scryfallCardToDeckCard(card: ScryfallCard): DeckCard {
+  const meta: CardMeta = {
+    name: card.name,
+    typeLine: card.type_line,
+    oracleText: card.oracle_text,
+    manaCost: card.mana_cost,
+    power: card.power,
+    toughness: card.toughness,
+  };
+
   if (card.image_uris?.normal) {
-    return { id: generateId(), src: [card.image_uris.normal] };
+    return { id: generateId(), src: [card.image_uris.normal], meta };
   }
   if (card.card_faces?.length) {
     return {
       id: generateId(),
       src: card.card_faces.map((face) => face.image_uris.normal),
+      meta,
     };
   }
   throw new Error(`No image found for card: ${card.name}`);

--- a/maginet-agent/src/scryfall.ts
+++ b/maginet-agent/src/scryfall.ts
@@ -41,7 +41,7 @@ export interface DeckCard {
 }
 
 function generateId(): string {
-  return Math.random().toString(36).substr(2, 9);
+  return Math.random().toString(36).slice(2, 11);
 }
 
 function shuffle<T>(array: T[]): T[] {

--- a/maginet-agent/src/scryfall.ts
+++ b/maginet-agent/src/scryfall.ts
@@ -1,0 +1,98 @@
+// maginet-agent/src/scryfall.ts
+
+interface ScryfallImageUris {
+  normal: string;
+  [key: string]: string;
+}
+
+interface ScryfallCardFace {
+  image_uris: ScryfallImageUris;
+}
+
+interface ScryfallCard {
+  image_uris?: ScryfallImageUris;
+  card_faces?: ScryfallCardFace[];
+  name: string;
+}
+
+interface ScryfallCollection {
+  data: ScryfallCard[];
+  not_found: Array<{ name: string }>;
+}
+
+export interface DeckCard {
+  id: string;
+  src: string[];
+}
+
+function generateId(): string {
+  return Math.random().toString(36).substr(2, 9);
+}
+
+function shuffle<T>(array: T[]): T[] {
+  return array
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}
+
+export function parseDeckList(deckList: string): string[] {
+  if (deckList.trim() === "") return [];
+  return deckList.split("\n").flatMap((line) => {
+    const match = line.match(/^(\d+)\s+(.*?)(?:\s*\/\/.*)?$/);
+    if (match) {
+      const [, count, name] = match;
+      return Array(Number(count)).fill(name.trim());
+    }
+    return [];
+  });
+}
+
+async function fetchCards(names: string[]): Promise<ScryfallCollection> {
+  const response = await fetch("https://api.scryfall.com/cards/collection", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      identifiers: names.map((name) => ({ name })),
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Scryfall API error: ${response.status} ${await response.text()}`);
+  }
+  return response.json() as Promise<ScryfallCollection>;
+}
+
+function scryfallCardToDeckCard(card: ScryfallCard): DeckCard {
+  if (card.image_uris?.normal) {
+    return { id: generateId(), src: [card.image_uris.normal] };
+  }
+  if (card.card_faces?.length) {
+    return {
+      id: generateId(),
+      src: card.card_faces.map((face) => face.image_uris.normal),
+    };
+  }
+  throw new Error(`No image found for card: ${card.name}`);
+}
+
+export async function loadDeckFromList(deckList: string): Promise<DeckCard[]> {
+  const names = parseDeckList(deckList);
+  if (names.length === 0) throw new Error("Empty deck list");
+  if (names.length > 200) throw new Error("Deck list too large (max 200 cards)");
+
+  const chunks: string[][] = [];
+  const remaining = [...names];
+  while (remaining.length > 0) {
+    chunks.push(remaining.splice(0, 75));
+  }
+
+  const collections = await Promise.all(chunks.map(fetchCards));
+
+  const notFound = collections.flatMap((c) => c.not_found.map((nf) => nf.name));
+  if (notFound.length > 0) {
+    console.warn(`Cards not found: ${notFound.join(", ")}`);
+  }
+
+  const cards = collections.flatMap((c) => c.data.map(scryfallCardToDeckCard));
+  return shuffle(cards);
+}

--- a/maginet-agent/src/scryfall.ts
+++ b/maginet-agent/src/scryfall.ts
@@ -100,6 +100,36 @@ function scryfallCardToDeckCard(card: ScryfallCard): DeckCard {
   throw new Error(`No image found for card: ${card.name}`);
 }
 
+/** Extract Scryfall card UUID from an image URL like https://cards.scryfall.io/normal/front/2/d/2dfe1926-...jpg */
+function extractScryfallUuid(imageUrl: string): string | null {
+  const match = imageUrl.match(/\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\./);
+  return match?.[1] ?? null;
+}
+
+/** Fetch card metadata from Scryfall by image URL. Returns null if lookup fails. */
+export async function fetchCardMetaByImageUrl(imageUrl: string): Promise<{ imageUrl: string; meta: CardMeta } | null> {
+  const uuid = extractScryfallUuid(imageUrl);
+  if (!uuid) return null;
+  try {
+    const response = await fetch(`https://api.scryfall.com/cards/${uuid}`);
+    if (!response.ok) return null;
+    const card = await response.json() as ScryfallCard;
+    return {
+      imageUrl,
+      meta: {
+        name: card.name,
+        typeLine: card.type_line,
+        oracleText: card.oracle_text ?? (card.card_faces as unknown as ScryfallCard[])?.[0]?.oracle_text,
+        manaCost: card.mana_cost ?? (card.card_faces as unknown as ScryfallCard[])?.[0]?.mana_cost,
+        power: card.power,
+        toughness: card.toughness,
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
 export async function loadDeckFromList(deckList: string): Promise<DeckCard[]> {
   const names = parseDeckList(deckList);
   if (names.length === 0) throw new Error("Empty deck list");

--- a/maginet-agent/src/scryfall.ts
+++ b/maginet-agent/src/scryfall.ts
@@ -45,10 +45,12 @@ function generateId(): string {
 }
 
 function shuffle<T>(array: T[]): T[] {
-  return array
-    .map((value) => ({ value, sort: Math.random() }))
-    .sort((a, b) => a.sort - b.sort)
-    .map(({ value }) => value);
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
 }
 
 export function parseDeckList(deckList: string): string[] {
@@ -91,11 +93,14 @@ function scryfallCardToDeckCard(card: ScryfallCard): DeckCard {
     return { id: generateId(), src: [card.image_uris.normal], meta };
   }
   if (card.card_faces?.length) {
-    return {
-      id: generateId(),
-      src: card.card_faces.map((face) => face.image_uris.normal),
-      meta,
-    };
+    const facesWithImages = card.card_faces.filter((face) => face.image_uris?.normal);
+    if (facesWithImages.length > 0) {
+      return {
+        id: generateId(),
+        src: facesWithImages.map((face) => face.image_uris.normal),
+        meta,
+      };
+    }
   }
   throw new Error(`No image found for card: ${card.name}`);
 }
@@ -135,8 +140,16 @@ export async function loadDeckFromList(deckList: string): Promise<DeckCard[]> {
   if (names.length === 0) throw new Error("Empty deck list");
   if (names.length > 200) throw new Error("Deck list too large (max 200 cards)");
 
+  // Count how many copies of each card are needed
+  const countMap = new Map<string, number>();
+  for (const name of names) {
+    countMap.set(name, (countMap.get(name) ?? 0) + 1);
+  }
+
+  // Send only unique names to Scryfall (it deduplicates anyway)
+  const uniqueNames = [...countMap.keys()];
   const chunks: string[][] = [];
-  const remaining = [...names];
+  const remaining = [...uniqueNames];
   while (remaining.length > 0) {
     chunks.push(remaining.splice(0, 75));
   }
@@ -148,6 +161,12 @@ export async function loadDeckFromList(deckList: string): Promise<DeckCard[]> {
     console.warn(`Cards not found: ${notFound.join(", ")}`);
   }
 
-  const cards = collections.flatMap((c) => c.data.map(scryfallCardToDeckCard));
+  // Expand each Scryfall result back to the requested number of copies
+  const cards = collections.flatMap((c) =>
+    c.data.flatMap((scryfallCard) => {
+      const count = countMap.get(scryfallCard.name) ?? 1;
+      return Array.from({ length: count }, () => scryfallCardToDeckCard(scryfallCard));
+    })
+  );
   return shuffle(cards);
 }

--- a/maginet-agent/src/server.ts
+++ b/maginet-agent/src/server.ts
@@ -30,7 +30,7 @@ export class AgentWebSocketServer {
     return new Promise((resolve, reject) => {
       this.wss = new WebSocketServer({ port: this.port }, () => {
         const address = this.wss!.address();
-        const assignedPort = typeof address === "object" ? address.port : this.port;
+        const assignedPort = address !== null && typeof address === "object" ? address.port : this.port;
         resolve(assignedPort);
       });
 

--- a/maginet-agent/src/server.ts
+++ b/maginet-agent/src/server.ts
@@ -34,7 +34,11 @@ export class AgentWebSocketServer {
         resolve(assignedPort);
       });
 
-      this.wss.on("error", reject);
+      this.wss.on("error", (err) => {
+        // Reject during startup; log after startup
+        reject(err);
+        console.error("[maginet-agent] WebSocket server error:", err);
+      });
 
       this.wss.on("connection", (ws) => {
         // Close previous client if browser reconnects (e.g. page refresh)

--- a/maginet-agent/src/server.ts
+++ b/maginet-agent/src/server.ts
@@ -1,0 +1,105 @@
+import { WebSocketServer, WebSocket } from "ws";
+
+export interface SyncEnvelope {
+  type: string;
+  payload: unknown;
+  meta?: Record<string, unknown>;
+}
+
+export interface AgentWebSocketServerOptions {
+  port: number;
+}
+
+type MessageListener = (message: SyncEnvelope) => void;
+type ConnectionListener = (peerId: string) => void;
+
+export class AgentWebSocketServer {
+  private wss: WebSocketServer | null = null;
+  private client: WebSocket | null = null;
+  private port: number;
+  private messageListeners = new Set<MessageListener>();
+  private connectListeners = new Set<ConnectionListener>();
+  private disconnectListeners = new Set<ConnectionListener>();
+  private browserPeerId = "browser";
+
+  constructor(options: AgentWebSocketServerOptions) {
+    this.port = options.port;
+  }
+
+  async start(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.wss = new WebSocketServer({ port: this.port }, () => {
+        const address = this.wss!.address();
+        const assignedPort = typeof address === "object" ? address.port : this.port;
+        resolve(assignedPort);
+      });
+
+      this.wss.on("error", reject);
+
+      this.wss.on("connection", (ws) => {
+        this.client = ws;
+        this.connectListeners.forEach((listener) => listener(this.browserPeerId));
+
+        ws.on("message", (data) => {
+          try {
+            const message = JSON.parse(data.toString()) as SyncEnvelope;
+            this.messageListeners.forEach((listener) => listener(message));
+          } catch {
+            // Ignore malformed messages
+          }
+        });
+
+        ws.on("close", () => {
+          this.client = null;
+          this.disconnectListeners.forEach((listener) => listener(this.browserPeerId));
+        });
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.client) {
+      this.client.close();
+      this.client = null;
+    }
+    return new Promise((resolve) => {
+      if (!this.wss) { resolve(); return; }
+      this.wss.close(() => {
+        this.wss = null;
+        resolve();
+      });
+    });
+  }
+
+  isConnected(): boolean {
+    return this.client !== null && this.client.readyState === WebSocket.OPEN;
+  }
+
+  send(message: SyncEnvelope): void {
+    if (!this.client || this.client.readyState !== WebSocket.OPEN) return;
+    this.client.send(JSON.stringify(message));
+  }
+
+  onMessage(listener: MessageListener): () => void {
+    this.messageListeners.add(listener);
+    return () => { this.messageListeners.delete(listener); };
+  }
+
+  onConnect(listener: ConnectionListener): () => void {
+    this.connectListeners.add(listener);
+    return () => { this.connectListeners.delete(listener); };
+  }
+
+  onDisconnect(listener: ConnectionListener): () => void {
+    this.disconnectListeners.add(listener);
+    return () => { this.disconnectListeners.delete(listener); };
+  }
+
+  getBrowserPeerId(): string {
+    return this.browserPeerId;
+  }
+
+  setBrowserPeerId(peerId: string): void {
+    this.browserPeerId = peerId;
+  }
+}

--- a/maginet-agent/src/server.ts
+++ b/maginet-agent/src/server.ts
@@ -37,6 +37,10 @@ export class AgentWebSocketServer {
       this.wss.on("error", reject);
 
       this.wss.on("connection", (ws) => {
+        // Close previous client if browser reconnects (e.g. page refresh)
+        if (this.client && this.client.readyState === WebSocket.OPEN) {
+          this.client.close();
+        }
         this.client = ws;
         this.connectListeners.forEach((listener) => listener(this.browserPeerId));
 

--- a/maginet-agent/src/state.ts
+++ b/maginet-agent/src/state.ts
@@ -48,17 +48,67 @@ function generateId(): string {
 }
 
 function shuffle<T>(array: T[]): T[] {
-  return array
-    .map((value) => ({ value, sort: Math.random() }))
-    .sort((a, b) => a.sort - b.sort)
-    .map(({ value }) => value);
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
 }
+
+interface Snapshot {
+  cardState: CardState;
+  agentShapes: Shape[];
+}
+
+const MAX_UNDO_HISTORY = 30;
 
 export class AgentGameState {
   private cardState: CardState = { cards: [], deck: [], actionId: 0 };
   private agentShapes: Shape[] = [];
   private shapeListeners = new Set<(next: Shape[], prev: Shape[]) => void>();
   private cardMetaByImage = new Map<string, CardMeta>();
+  private undoStack: Snapshot[] = [];
+  private redoStack: Snapshot[] = [];
+
+  private saveSnapshot(): void {
+    this.undoStack.push({
+      cardState: { ...this.cardState, cards: [...this.cardState.cards], deck: [...this.cardState.deck] },
+      agentShapes: this.agentShapes.map((s) => ({ ...s })),
+    });
+    if (this.undoStack.length > MAX_UNDO_HISTORY) {
+      this.undoStack.shift();
+    }
+    this.redoStack = [];
+  }
+
+  undo(): boolean {
+    const snapshot = this.undoStack.pop();
+    if (!snapshot) return false;
+    this.redoStack.push({
+      cardState: { ...this.cardState, cards: [...this.cardState.cards], deck: [...this.cardState.deck] },
+      agentShapes: this.agentShapes.map((s) => ({ ...s })),
+    });
+    const prev = this.agentShapes;
+    this.cardState = snapshot.cardState;
+    this.agentShapes = snapshot.agentShapes;
+    this.notifyShapeChange(prev);
+    return true;
+  }
+
+  redo(): boolean {
+    const snapshot = this.redoStack.pop();
+    if (!snapshot) return false;
+    this.undoStack.push({
+      cardState: { ...this.cardState, cards: [...this.cardState.cards], deck: [...this.cardState.deck] },
+      agentShapes: this.agentShapes.map((s) => ({ ...s })),
+    });
+    const prev = this.agentShapes;
+    this.cardState = snapshot.cardState;
+    this.agentShapes = snapshot.agentShapes;
+    this.notifyShapeChange(prev);
+    return true;
+  }
 
   lookupCardMeta(imageUrl: string): CardMeta | undefined {
     return this.cardMetaByImage.get(imageUrl);
@@ -129,6 +179,7 @@ export class AgentGameState {
 
   drawCard(): Card | null {
     if (this.cardState.deck.length === 0) return null;
+    this.saveSnapshot();
     this.nextAction("DRAW_CARD");
     const [drawn, ...rest] = this.cardState.deck;
     const drawnCard = { ...drawn, id: generateId() };
@@ -141,6 +192,7 @@ export class AgentGameState {
   }
 
   mulligan(): void {
+    this.saveSnapshot();
     this.nextAction("MULLIGAN");
     this.cardState = {
       ...this.cardState,
@@ -152,6 +204,7 @@ export class AgentGameState {
   playCard(cardId: string): Card | null {
     const card = this.cardState.cards.find((c) => c.id === cardId);
     if (!card) return null;
+    this.saveSnapshot();
     this.nextAction("PLAY_CARD");
     this.cardState = {
       ...this.cardState,
@@ -188,12 +241,14 @@ export class AgentGameState {
   }
 
   addAgentShape(shape: Shape): void {
+    this.saveSnapshot();
     const prev = this.agentShapes;
     this.agentShapes = [...this.agentShapes, shape];
     this.notifyShapeChange(prev);
   }
 
   removeAgentShape(shapeId: string): void {
+    this.saveSnapshot();
     const prev = this.agentShapes;
     this.agentShapes = this.agentShapes.filter((s) => s.id !== shapeId);
     this.notifyShapeChange(prev);
@@ -204,6 +259,22 @@ export class AgentGameState {
     this.agentShapes = this.agentShapes.map((s) =>
       s.id === shapeId ? { ...s, ...updates } : s
     );
+    this.notifyShapeChange(prev);
+  }
+
+  /** Batch-update multiple shapes, notifying listeners only once. */
+  updateAgentShapes(updatesById: Map<string, Partial<Shape>>): void {
+    const prev = this.agentShapes;
+    this.agentShapes = this.agentShapes.map((s) => {
+      const updates = updatesById.get(s.id);
+      return updates ? { ...s, ...updates } : s;
+    });
+    this.notifyShapeChange(prev);
+  }
+
+  clearAgentShapes(): void {
+    const prev = this.agentShapes;
+    this.agentShapes = [];
     this.notifyShapeChange(prev);
   }
 

--- a/maginet-agent/src/state.ts
+++ b/maginet-agent/src/state.ts
@@ -69,6 +69,10 @@ export class AgentGameState {
     return this.cardMetaByImage.get(shape.src[0]);
   }
 
+  registerCardMeta(imageUrl: string, meta: CardMeta): void {
+    this.cardMetaByImage.set(imageUrl, meta);
+  }
+
   getHand(): Card[] {
     return this.cardState.cards;
   }

--- a/maginet-agent/src/state.ts
+++ b/maginet-agent/src/state.ts
@@ -1,0 +1,183 @@
+export interface Card {
+  id: string;
+  src: string[];
+}
+
+export interface CardState {
+  cards: Card[];
+  deck: Card[];
+  lastAction?: string;
+  actionId?: number;
+}
+
+export interface Counter {
+  label: string;
+  power?: number;
+  toughness?: number;
+  value?: number;
+  color?: string;
+}
+
+export interface Shape {
+  id: string;
+  point: number[];
+  size: number[];
+  type: "rectangle" | "circle" | "arrow" | "text" | "image" | "token";
+  text?: string;
+  src?: string[];
+  srcIndex: number;
+  rotation?: number;
+  isFlipped?: boolean;
+  fontSize?: number;
+  counters?: Counter[];
+  color?: string;
+}
+
+function generateId(): string {
+  return Math.random().toString(36).substr(2, 9);
+}
+
+function shuffle<T>(array: T[]): T[] {
+  return array
+    .map((value) => ({ value, sort: Math.random() }))
+    .sort((a, b) => a.sort - b.sort)
+    .map(({ value }) => value);
+}
+
+export class AgentGameState {
+  private cardState: CardState = { cards: [], deck: [], actionId: 0 };
+  private agentShapes: Shape[] = [];
+  private shapeListeners = new Set<(next: Shape[], prev: Shape[]) => void>();
+
+  getHand(): Card[] {
+    return this.cardState.cards;
+  }
+
+  getDeckSize(): number {
+    return this.cardState.deck.length;
+  }
+
+  getDeckContents(): Card[] {
+    return this.cardState.deck;
+  }
+
+  getCardState(): CardState {
+    return this.cardState;
+  }
+
+  getAgentShapes(): Shape[] {
+    return this.agentShapes;
+  }
+
+  subscribeShapes(listener: (next: Shape[], prev: Shape[]) => void): () => void {
+    this.shapeListeners.add(listener);
+    return () => {
+      this.shapeListeners.delete(listener);
+    };
+  }
+
+  private notifyShapeChange(prev: Shape[]): void {
+    this.shapeListeners.forEach((listener) => listener(this.agentShapes, prev));
+  }
+
+  private nextAction(action: string): void {
+    this.cardState = {
+      ...this.cardState,
+      lastAction: action,
+      actionId: (this.cardState.actionId ?? 0) + 1,
+    };
+  }
+
+  initializeDeck(cards: Card[]): void {
+    this.nextAction("INITIALIZE_DECK");
+    this.cardState = {
+      ...this.cardState,
+      deck: cards.map((c) => ({ ...c })),
+      cards: [],
+    };
+  }
+
+  drawCard(): Card | null {
+    if (this.cardState.deck.length === 0) return null;
+    this.nextAction("DRAW_CARD");
+    const [drawn, ...rest] = this.cardState.deck;
+    const drawnCard = { ...drawn, id: generateId() };
+    this.cardState = {
+      ...this.cardState,
+      deck: rest,
+      cards: [...this.cardState.cards, drawnCard],
+    };
+    return drawnCard;
+  }
+
+  mulligan(): void {
+    this.nextAction("MULLIGAN");
+    this.cardState = {
+      ...this.cardState,
+      deck: [...this.cardState.deck, ...this.cardState.cards],
+      cards: [],
+    };
+  }
+
+  playCard(cardId: string): Card | null {
+    const card = this.cardState.cards.find((c) => c.id === cardId);
+    if (!card) return null;
+    this.nextAction("PLAY_CARD");
+    this.cardState = {
+      ...this.cardState,
+      cards: this.cardState.cards.filter((c) => c.id !== cardId),
+    };
+    return card;
+  }
+
+  sendToHand(cards: Card[]): void {
+    this.nextAction("SEND_TO_HAND");
+    this.cardState = {
+      ...this.cardState,
+      cards: [...this.cardState.cards, ...cards],
+    };
+  }
+
+  sendToDeck(cards: Card[], position: "top" | "bottom"): void {
+    this.nextAction("SEND_TO_DECK");
+    this.cardState = {
+      ...this.cardState,
+      deck:
+        position === "top"
+          ? [...cards, ...this.cardState.deck]
+          : [...this.cardState.deck, ...cards],
+    };
+  }
+
+  shuffleDeck(): void {
+    this.nextAction("SHUFFLE_DECK");
+    this.cardState = {
+      ...this.cardState,
+      deck: shuffle(this.cardState.deck),
+    };
+  }
+
+  addAgentShape(shape: Shape): void {
+    const prev = this.agentShapes;
+    this.agentShapes = [...this.agentShapes, shape];
+    this.notifyShapeChange(prev);
+  }
+
+  removeAgentShape(shapeId: string): void {
+    const prev = this.agentShapes;
+    this.agentShapes = this.agentShapes.filter((s) => s.id !== shapeId);
+    this.notifyShapeChange(prev);
+  }
+
+  updateAgentShape(shapeId: string, updates: Partial<Shape>): void {
+    const prev = this.agentShapes;
+    this.agentShapes = this.agentShapes.map((s) =>
+      s.id === shapeId ? { ...s, ...updates } : s
+    );
+    this.notifyShapeChange(prev);
+  }
+
+  findAgentShape(shapeId: string): Shape | undefined {
+    return this.agentShapes.find((s) => s.id === shapeId);
+  }
+}

--- a/maginet-agent/src/state.ts
+++ b/maginet-agent/src/state.ts
@@ -44,7 +44,7 @@ export interface Shape {
 }
 
 function generateId(): string {
-  return Math.random().toString(36).substr(2, 9);
+  return Math.random().toString(36).slice(2, 11);
 }
 
 function shuffle<T>(array: T[]): T[] {

--- a/maginet-agent/src/state.ts
+++ b/maginet-agent/src/state.ts
@@ -1,6 +1,16 @@
+export interface CardMeta {
+  name: string;
+  typeLine?: string;
+  oracleText?: string;
+  manaCost?: string;
+  power?: string;
+  toughness?: string;
+}
+
 export interface Card {
   id: string;
   src: string[];
+  meta?: CardMeta;
 }
 
 export interface CardState {
@@ -48,6 +58,16 @@ export class AgentGameState {
   private cardState: CardState = { cards: [], deck: [], actionId: 0 };
   private agentShapes: Shape[] = [];
   private shapeListeners = new Set<(next: Shape[], prev: Shape[]) => void>();
+  private cardMetaByImage = new Map<string, CardMeta>();
+
+  lookupCardMeta(imageUrl: string): CardMeta | undefined {
+    return this.cardMetaByImage.get(imageUrl);
+  }
+
+  lookupShapeMeta(shape: Shape): CardMeta | undefined {
+    if (!shape.src?.length) return undefined;
+    return this.cardMetaByImage.get(shape.src[0]);
+  }
 
   getHand(): Card[] {
     return this.cardState.cards;
@@ -95,6 +115,12 @@ export class AgentGameState {
       deck: cards.map((c) => ({ ...c })),
       cards: [],
     };
+    // Build image URL → metadata lookup
+    for (const card of cards) {
+      if (card.meta && card.src.length > 0) {
+        this.cardMetaByImage.set(card.src[0], card.meta);
+      }
+    }
   }
 
   drawCard(): Card | null {

--- a/maginet-agent/src/visibility.ts
+++ b/maginet-agent/src/visibility.ts
@@ -12,6 +12,7 @@ export interface RawGameState {
   agentDeck: Card[];
   boardShapes: Record<string, Shape[]>;
   opponentHand: Card[];
+  opponentHandCount: number;
   opponentDeckSize: number;
 }
 
@@ -33,7 +34,7 @@ export function filterGameState(
     agentHand: raw.agentHand,
     agentDeckSize: raw.agentDeck.length,
     boardShapes: raw.boardShapes,
-    opponentHandCount: raw.opponentHand.length,
+    opponentHandCount: raw.opponentHandCount || raw.opponentHand.length,
     opponentDeckSize: raw.opponentDeckSize,
   };
 

--- a/maginet-agent/src/visibility.ts
+++ b/maginet-agent/src/visibility.ts
@@ -1,0 +1,46 @@
+import type { Shape } from "./state.js";
+
+export type Visibility = "fair" | "full";
+
+export interface Card {
+  id: string;
+  src: string[];
+}
+
+export interface RawGameState {
+  agentHand: Card[];
+  agentDeck: Card[];
+  boardShapes: Record<string, Shape[]>;
+  opponentHand: Card[];
+  opponentDeckSize: number;
+}
+
+export interface VisibleGameState {
+  agentHand: Card[];
+  agentDeckSize: number;
+  agentDeckContents?: Card[];
+  boardShapes: Record<string, Shape[]>;
+  opponentHandCount: number;
+  opponentHandContents?: Card[];
+  opponentDeckSize: number;
+}
+
+export function filterGameState(
+  raw: RawGameState,
+  visibility: Visibility
+): VisibleGameState {
+  const base: VisibleGameState = {
+    agentHand: raw.agentHand,
+    agentDeckSize: raw.agentDeck.length,
+    boardShapes: raw.boardShapes,
+    opponentHandCount: raw.opponentHand.length,
+    opponentDeckSize: raw.opponentDeckSize,
+  };
+
+  if (visibility === "full") {
+    base.agentDeckContents = raw.agentDeck;
+    base.opponentHandContents = raw.opponentHand;
+  }
+
+  return base;
+}

--- a/maginet-agent/tsconfig.json
+++ b/maginet-agent/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src"]
+}

--- a/src/board/ActionLog.tsx
+++ b/src/board/ActionLog.tsx
@@ -6,6 +6,7 @@ export type ActionLogEntry = {
   action: string;
   cardsInHand: number;
   timestamp?: number;
+  cardSrcs?: string[][];
 };
 
 export default function ActionLog({

--- a/src/board/SelectionPanel.tsx
+++ b/src/board/SelectionPanel.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useLocation, Form } from "react-router-dom";
 import useModal from "../hooks/useModal";
-import { usePeerStore } from "../hooks/usePeerConnection";
+import { usePeerStore, connectAgent, disconnectAgent } from "../hooks/usePeerConnection";
 import { useShapeStore } from "../hooks/useShapeStore";
 import { Datum } from "../hooks/useCards";
 import { Camera, Mode, Card, ShapeType } from "../types/canvas";
@@ -448,6 +448,27 @@ export function SelectionPanel({
     );
   };
 
+  // Agent connection state
+  const [agentConnected, setAgentConnected] = React.useState(false);
+  const [agentConnecting, setAgentConnecting] = React.useState(false);
+
+  const handleToggleAgent = async () => {
+    if (agentConnected) {
+      void disconnectAgent();
+      setAgentConnected(false);
+      return;
+    }
+    setAgentConnecting(true);
+    try {
+      await connectAgent();
+      setAgentConnected(true);
+    } catch {
+      setAgentConnected(false);
+    } finally {
+      setAgentConnecting(false);
+    }
+  };
+
   return (
     <div className="selection-panel selection-panel--integrated fixed inset-0 z-(--z-selection-panel) pointer-events-none text-win-text font-win p-0">
       <div className="selection-panel__group selection-panel__group--top-left absolute flex items-center gap-2.5 pointer-events-auto top-4 left-4 max-[720px]:top-3 max-[720px]:left-3 max-[720px]:flex-col max-[720px]:items-start">
@@ -484,6 +505,13 @@ export function SelectionPanel({
         </button>
         <button className="selection-panel__pill" onClick={openConnectModal}>
           Connect
+        </button>
+        <button
+          className={`selection-panel__pill${agentConnected ? " is-active" : ""}`}
+          onClick={handleToggleAgent}
+          disabled={agentConnecting}
+        >
+          {agentConnecting ? "Connecting..." : agentConnected ? "Agent On" : "Agent"}
         </button>
         {isMobile && (
           <button className="selection-panel__pill danger" onClick={onMulligan}>

--- a/src/board/components/SetupScreen.tsx
+++ b/src/board/components/SetupScreen.tsx
@@ -6,6 +6,7 @@ import type Peer from "peerjs";
 import type { DataConnection } from "peerjs";
 import Button from "../../components/ui/Button";
 import Input, { Textarea } from "../../components/ui/Input";
+import { connectAgent, disconnectAgent } from "../../sync/react/peerStore";
 
 interface SetupScreenProps {
   deckParam: string;
@@ -40,6 +41,26 @@ export default function SetupScreen({
   const [setupError, setSetupError] = useState<string | null>(null);
   const [setupPeerId, setSetupPeerId] = useState("");
   const [setupCopied, setSetupCopied] = useState(false);
+  const [agentPort, setAgentPort] = useState("3210");
+  const [agentConnected, setAgentConnected] = useState(false);
+  const [agentConnecting, setAgentConnecting] = useState(false);
+
+  const handleConnectAgent = async () => {
+    setAgentConnecting(true);
+    try {
+      await connectAgent(parseInt(agentPort, 10));
+      setAgentConnected(true);
+    } catch {
+      setAgentConnected(false);
+    } finally {
+      setAgentConnecting(false);
+    }
+  };
+
+  const handleDisconnectAgent = () => {
+    void disconnectAgent();
+    setAgentConnected(false);
+  };
 
   const deckDraftCount = processRawText(deckDraft).length;
 
@@ -207,6 +228,44 @@ export default function SetupScreen({
                 </div>
                 <div className="setup-hint text-[11px] text-win-text-muted">
                   Share this ID so a friend can connect to you.
+                </div>
+              </div>
+              <div className="setup-panel win-bevel flex flex-col gap-2 rounded bg-win-bg-light p-2.5 col-span-2 max-[720px]:col-span-1">
+                <label className="setup-label text-[11px] tracking-[0.12em] uppercase text-win-text-muted">
+                  AI Agent
+                </label>
+                <div className="setup-input-row flex gap-2.5 items-center max-[720px]:flex-col max-[720px]:items-stretch">
+                  <Input
+                    className="setup-input w-24 p-3 text-[13px] leading-[1.4] shadow-none"
+                    type="text"
+                    value={agentPort}
+                    onChange={(event) => setAgentPort(event.target.value)}
+                    placeholder="Port"
+                    disabled={agentConnected}
+                  />
+                  {agentConnected ? (
+                    <Button
+                      type="button"
+                      className="setup-button ghost rounded px-3.5 py-2 text-xs bg-win-header-bg"
+                      onClick={handleDisconnectAgent}
+                    >
+                      Disconnect
+                    </Button>
+                  ) : (
+                    <Button
+                      type="button"
+                      className="setup-button primary rounded px-3.5 py-2 text-xs bg-win-hover hover:bg-[#f5f5f5]"
+                      onClick={handleConnectAgent}
+                      disabled={agentConnecting}
+                    >
+                      {agentConnecting ? "Connecting..." : "Connect Agent"}
+                    </Button>
+                  )}
+                </div>
+                <div className="setup-hint text-[11px] text-win-text-muted">
+                  {agentConnected
+                    ? "Agent connected. It will appear as a player on the board."
+                    : "Connect to a local MCP agent for AI play or copilot advice."}
                 </div>
               </div>
             </div>

--- a/src/hooks/useCardReducer.ts
+++ b/src/hooks/useCardReducer.ts
@@ -7,6 +7,7 @@ export type CardState = {
   cards: Card[];
   deck: Card[];
   lastAction?: string;
+  lastPlayedSrcs?: string[][];
   actionId?: number;
 };
 
@@ -95,11 +96,14 @@ export function cardReducer(state: CardState, action: CardAction): CardState {
         deck: nextDeck,
       };
     }
-    case "PLAY_CARD":
+    case "PLAY_CARD": {
+      const playedCards = state.cards.filter((card) => action.payload.includes(card.id));
       return {
         ...baseState,
+        lastPlayedSrcs: playedCards.map((c) => c.src),
         cards: state.cards.filter((card) => !action.payload.includes(card.id)),
       };
+    }
     case "SHUFFLE_DECK":
       return {
         ...baseState,

--- a/src/hooks/usePeerConnection.ts
+++ b/src/hooks/usePeerConnection.ts
@@ -1,5 +1,8 @@
 export {
   usePeerStore,
+  connectAgent,
+  disconnectAgent,
+  isAgentConnected,
   type Message,
   type MessageCallback,
   type PeerState,

--- a/src/sync/react/peerStore.ts
+++ b/src/sync/react/peerStore.ts
@@ -8,6 +8,7 @@ import {
 } from "@vescofire/peersync";
 import { createPeerJsTransport } from "@vescofire/peersync/peerjs";
 import { createShapesSyncChannel } from "./shapesChannel";
+import { createWebSocketTransport } from "../transport/websocket";
 
 export type Message<TPayload = unknown> = SyncEnvelope<string, TPayload>;
 
@@ -192,3 +193,52 @@ export const usePeerStore = create<PeerState>((_, get) => ({
     return syncClient.onMessage(type, callback as MessageCallback);
   },
 }));
+
+let agentSyncClient: ReturnType<typeof createSyncClient> | null = null;
+let agentTransport: ReturnType<typeof createWebSocketTransport> | null = null;
+
+export const connectAgent = async (port: number = 3210): Promise<void> => {
+  if (agentSyncClient) {
+    await agentSyncClient.stop();
+  }
+
+  agentTransport = createWebSocketTransport({
+    url: `ws://localhost:${port}`,
+    onConnected: () => {
+      console.log("[maginet] Agent connected");
+    },
+    onDisconnected: () => {
+      console.log("[maginet] Agent disconnected");
+      agentSyncClient = null;
+      agentTransport = null;
+    },
+    onError: (error) => {
+      setPeerError(error);
+    },
+  });
+
+  agentSyncClient = createSyncClient({
+    roomId: "maginet-agent",
+    transport: agentTransport,
+  });
+
+  agentSyncClient.registerChannel(
+    createShapesSyncChannel({
+      getLocalPeerId: () => usePeerStore.getState().peer?.id ?? "browser",
+    })
+  );
+
+  await agentSyncClient.start();
+};
+
+export const disconnectAgent = async (): Promise<void> => {
+  if (agentSyncClient) {
+    await agentSyncClient.stop();
+    agentSyncClient = null;
+    agentTransport = null;
+  }
+};
+
+export const isAgentConnected = (): boolean => {
+  return agentTransport !== null && agentSyncClient !== null;
+};

--- a/src/sync/react/peerStore.ts
+++ b/src/sync/react/peerStore.ts
@@ -20,6 +20,7 @@ export type MessageCallback<TPayload = unknown> = (
 export interface PeerState {
   peer: Peer | null;
   connections: Map<string, DataConnection>;
+  connectedAgentPeerIds: Set<string>;
   error: Error | null;
   initPeer: () => () => void;
   connectToPeer: (peerId: string) => void;
@@ -154,6 +155,7 @@ const acquirePeerRuntimeLease = () => {
 export const usePeerStore = create<PeerState>((_, get) => ({
   peer: null,
   connections: new Map(),
+  connectedAgentPeerIds: new Set(),
   error: null,
 
   initPeer: () => {
@@ -202,15 +204,27 @@ export const connectAgent = async (port: number = 3210): Promise<void> => {
     await agentSyncClient.stop();
   }
 
+  const agentPeerId = "agent";
+
   agentTransport = createWebSocketTransport({
     url: `ws://localhost:${port}`,
     onConnected: () => {
       console.log("[maginet] Agent connected");
+      usePeerStore.setState((state) => {
+        const next = new Set(state.connectedAgentPeerIds);
+        next.add(agentPeerId);
+        return { connectedAgentPeerIds: next };
+      });
     },
     onDisconnected: () => {
       console.log("[maginet] Agent disconnected");
       agentSyncClient = null;
       agentTransport = null;
+      usePeerStore.setState((state) => {
+        const next = new Set(state.connectedAgentPeerIds);
+        next.delete(agentPeerId);
+        return { connectedAgentPeerIds: next };
+      });
     },
     onError: (error) => {
       setPeerError(error);
@@ -236,6 +250,11 @@ export const disconnectAgent = async (): Promise<void> => {
     await agentSyncClient.stop();
     agentSyncClient = null;
     agentTransport = null;
+    usePeerStore.setState((state) => {
+      const next = new Set(state.connectedAgentPeerIds);
+      next.delete("agent");
+      return { connectedAgentPeerIds: next };
+    });
   }
 };
 

--- a/src/sync/react/peerStore.ts
+++ b/src/sync/react/peerStore.ts
@@ -177,6 +177,11 @@ export const usePeerStore = create<PeerState>((_, get) => ({
 
   sendMessage: (message: Message, peerId?: string) => {
     syncClient.send(message, peerId);
+    // Forward to agent sync client so custom messages (action-log,
+    // heartbeat, etc.) reach the agent without manual sendAgentMessage calls
+    if (agentSyncClient) {
+      agentSyncClient.send(message, peerId);
+    }
   },
 
   disconnect: (peerId?: string) => {
@@ -267,8 +272,3 @@ export const isAgentConnected = (): boolean => {
   return agentTransport !== null && agentSyncClient !== null;
 };
 
-export const sendAgentMessage = (message: Message): void => {
-  if (agentSyncClient) {
-    agentSyncClient.send(message);
-  }
-};

--- a/src/sync/react/peerStore.ts
+++ b/src/sync/react/peerStore.ts
@@ -218,6 +218,7 @@ export const connectAgent = async (port: number = 3210): Promise<void> => {
     },
     onDisconnected: () => {
       console.log("[maginet] Agent disconnected");
+      const client = agentSyncClient;
       agentSyncClient = null;
       agentTransport = null;
       usePeerStore.setState((state) => {
@@ -225,6 +226,10 @@ export const connectAgent = async (port: number = 3210): Promise<void> => {
         next.delete(agentPeerId);
         return { connectedAgentPeerIds: next };
       });
+      // Clean up sync client subscriptions on unexpected disconnect
+      if (client) {
+        void client.stop();
+      }
     },
     onError: (error) => {
       setPeerError(error);

--- a/src/sync/react/peerStore.ts
+++ b/src/sync/react/peerStore.ts
@@ -261,3 +261,9 @@ export const disconnectAgent = async (): Promise<void> => {
 export const isAgentConnected = (): boolean => {
   return agentTransport !== null && agentSyncClient !== null;
 };
+
+export const sendAgentMessage = (message: Message): void => {
+  if (agentSyncClient) {
+    agentSyncClient.send(message);
+  }
+};

--- a/src/sync/react/usePeerSync.ts
+++ b/src/sync/react/usePeerSync.ts
@@ -102,17 +102,15 @@ export function usePeerSync(options: UsePeerSyncOptions) {
 
     addActionLogEntry(entry);
 
-    if (peer?.id) {
-      sendMessage({
-        type: "random-event",
-        payload: {
-          ...event,
-          peerId: peer.id,
-          playerName: localPlayerName,
-          timestamp: entry.timestamp,
-        },
-      });
-    }
+    sendMessage({
+      type: "random-event",
+      payload: {
+        ...event,
+        peerId: peer?.id ?? "local",
+        playerName: localPlayerName,
+        timestamp: entry.timestamp,
+      },
+    });
   };
 
   const rollCoin = () => {
@@ -165,9 +163,7 @@ export function usePeerSync(options: UsePeerSyncOptions) {
 
     addActionLogEntry(entry);
 
-    if (peer?.id) {
-      sendMessage({ type: "action-log", payload: entry });
-    }
+    sendMessage({ type: "action-log", payload: entry });
     sendMessage({ type: "card-state-sync", payload: { cards: cards.length, deck: options.deck.length } });
   }, [cardState.actionId, cardState.lastAction, cardState.lastPlayedSrcs, cards.length, options.deck.length, peer?.id, sendMessage]);
 

--- a/src/sync/react/usePeerSync.ts
+++ b/src/sync/react/usePeerSync.ts
@@ -32,13 +32,17 @@ const localPlayerName = generatePlayerName();
 const selectConnectedPeerSyncUiState = (
   state: PeerSyncUiState,
   connections: Map<string, unknown>,
+  agentPeerIds: Set<string>,
   localPeerId?: string
 ): PeerSyncUiState => {
   let changed = false;
 
+  const isConnected = (peerId: string) =>
+    connections.has(peerId) || agentPeerIds.has(peerId);
+
   const receivedDataMap = Object.fromEntries(
     Object.entries(state.receivedDataMap).filter(([peerId]) => {
-      const keep = connections.has(peerId);
+      const keep = isConnected(peerId);
       if (!keep) changed = true;
       return keep;
     })
@@ -46,7 +50,7 @@ const selectConnectedPeerSyncUiState = (
 
   const peerPresence = Object.fromEntries(
     Object.entries(state.peerPresence).filter(([peerId]) => {
-      const keep = connections.has(peerId) || peerId === localPeerId;
+      const keep = isConnected(peerId) || peerId === localPeerId;
       if (!keep) changed = true;
       return keep;
     })
@@ -54,7 +58,7 @@ const selectConnectedPeerSyncUiState = (
 
   const peerNames = Object.fromEntries(
     Object.entries(state.peerNames).filter(([peerId]) => {
-      const keep = connections.has(peerId) || peerId === localPeerId;
+      const keep = isConnected(peerId) || peerId === localPeerId;
       if (!keep) changed = true;
       return keep;
     })
@@ -72,7 +76,7 @@ const selectConnectedPeerSyncUiState = (
 
 export function usePeerSync(options: UsePeerSyncOptions) {
   const { cards, cardState } = options;
-  const { connectToPeer, initPeer, sendMessage, peer, error, connections } = usePeerStore();
+  const { connectToPeer, initPeer, sendMessage, peer, error, connections, connectedAgentPeerIds } = usePeerStore();
 
   const peerSyncUiState = useSyncExternalStore(
     subscribePeerSyncUiState,
@@ -80,8 +84,8 @@ export function usePeerSync(options: UsePeerSyncOptions) {
     getPeerSyncUiStateSnapshot
   );
   const connectedPeerSyncUiState = useMemo(
-    () => selectConnectedPeerSyncUiState(peerSyncUiState, connections, peer?.id),
-    [connections, peer?.id, peerSyncUiState]
+    () => selectConnectedPeerSyncUiState(peerSyncUiState, connections, connectedAgentPeerIds, peer?.id),
+    [connections, connectedAgentPeerIds, peer?.id, peerSyncUiState]
   );
 
   const lastLoggedActionId = useRef<number | undefined>(undefined);

--- a/src/sync/react/usePeerSync.ts
+++ b/src/sync/react/usePeerSync.ts
@@ -164,7 +164,14 @@ export function usePeerSync(options: UsePeerSyncOptions) {
     addActionLogEntry(entry);
 
     sendMessage({ type: "action-log", payload: entry });
-    sendMessage({ type: "card-state-sync", payload: { cards: cards.length, deck: options.deck.length } });
+    sendMessage({
+      type: "card-state-sync",
+      payload: {
+        cards: cards.length,
+        deck: options.deck.length,
+        hand: cards.map((c) => ({ id: c.id, src: c.src })),
+      },
+    });
   }, [cardState.actionId, cardState.lastAction, cardState.lastPlayedSrcs, cards.length, options.deck.length, peer?.id, sendMessage]);
 
   useEffect(() => {

--- a/src/sync/react/usePeerSync.ts
+++ b/src/sync/react/usePeerSync.ts
@@ -10,7 +10,6 @@ import {
 import { describeRandomEvent, generatePlayerName } from "../../utils/game";
 import {
   usePeerStore,
-  sendAgentMessage,
 } from "./peerStore";
 import {
   addActionLogEntry,
@@ -114,7 +113,6 @@ export function usePeerSync(options: UsePeerSyncOptions) {
         },
       });
     }
-    sendAgentMessage({ type: "action-log", payload: entry });
   };
 
   const rollCoin = () => {
@@ -162,6 +160,7 @@ export function usePeerSync(options: UsePeerSyncOptions) {
       action: description,
       cardsInHand: cards.length,
       timestamp: Date.now(),
+      cardSrcs: cardState.lastPlayedSrcs,
     };
 
     addActionLogEntry(entry);
@@ -169,8 +168,8 @@ export function usePeerSync(options: UsePeerSyncOptions) {
     if (peer?.id) {
       sendMessage({ type: "action-log", payload: entry });
     }
-    sendAgentMessage({ type: "action-log", payload: entry });
-  }, [cardState.actionId, cardState.lastAction, cards.length, peer?.id, sendMessage]);
+    sendMessage({ type: "card-state-sync", payload: { cards: cards.length, deck: options.deck.length } });
+  }, [cardState.actionId, cardState.lastAction, cardState.lastPlayedSrcs, cards.length, options.deck.length, peer?.id, sendMessage]);
 
   useEffect(() => {
     if (!peer?.id) return;

--- a/src/sync/react/usePeerSync.ts
+++ b/src/sync/react/usePeerSync.ts
@@ -10,6 +10,7 @@ import {
 import { describeRandomEvent, generatePlayerName } from "../../utils/game";
 import {
   usePeerStore,
+  sendAgentMessage,
 } from "./peerStore";
 import {
   addActionLogEntry,
@@ -113,6 +114,7 @@ export function usePeerSync(options: UsePeerSyncOptions) {
         },
       });
     }
+    sendAgentMessage({ type: "action-log", payload: entry });
   };
 
   const rollCoin = () => {
@@ -167,6 +169,7 @@ export function usePeerSync(options: UsePeerSyncOptions) {
     if (peer?.id) {
       sendMessage({ type: "action-log", payload: entry });
     }
+    sendAgentMessage({ type: "action-log", payload: entry });
   }, [cardState.actionId, cardState.lastAction, cards.length, peer?.id, sendMessage]);
 
   useEffect(() => {

--- a/src/sync/transport/websocket.test.ts
+++ b/src/sync/transport/websocket.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createWebSocketTransport } from "./websocket";
+
+// Mock WebSocket
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  url: string;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  sentMessages: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+
+  // Test helpers
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  simulateMessage(data: string) {
+    this.onmessage?.({ data });
+  }
+
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+describe("createWebSocketTransport", () => {
+  let mockWs: MockWebSocket;
+
+  beforeEach(() => {
+    mockWs = new MockWebSocket("ws://localhost:3210");
+    vi.stubGlobal("WebSocket", class extends MockWebSocket {
+      constructor(url: string) {
+        super(url);
+        mockWs = this;
+      }
+    });
+  });
+
+  it("creates a transport with the correct interface", () => {
+    const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
+    expect(transport.start).toBeDefined();
+    expect(transport.stop).toBeDefined();
+    expect(transport.send).toBeDefined();
+    expect(transport.broadcast).toBeDefined();
+    expect(transport.onMessage).toBeDefined();
+    expect(transport.peers).toBeDefined();
+    expect(transport.localPeerId).toBeDefined();
+  });
+
+  it("connects on start and reports agent as peer", async () => {
+    const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
+
+    const startPromise = transport.start();
+    mockWs.simulateOpen();
+    await startPromise;
+
+    expect(transport.peers()).toEqual(["agent"]);
+  });
+
+  it("sends JSON-serialized envelopes", async () => {
+    const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
+
+    const startPromise = transport.start();
+    mockWs.simulateOpen();
+    await startPromise;
+
+    const envelope = { type: "test", payload: { value: 1 } };
+    transport.send("agent", envelope);
+
+    expect(mockWs.sentMessages).toHaveLength(1);
+    expect(JSON.parse(mockWs.sentMessages[0])).toEqual(envelope);
+  });
+
+  it("receives and deserializes messages", async () => {
+    const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
+
+    const startPromise = transport.start();
+    mockWs.simulateOpen();
+    await startPromise;
+
+    const received: unknown[] = [];
+    transport.onMessage((_, msg) => received.push(msg));
+
+    mockWs.simulateMessage(JSON.stringify({ type: "hello", payload: {} }));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ type: "hello", payload: {} });
+  });
+
+  it("calls onConnectionClose when socket closes", async () => {
+    const onClose = vi.fn();
+    const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
+
+    const startPromise = transport.start();
+    mockWs.simulateOpen();
+    await startPromise;
+
+    transport.onConnectionClose!(onClose);
+    mockWs.simulateClose();
+
+    expect(onClose).toHaveBeenCalledWith("agent");
+  });
+});

--- a/src/sync/transport/websocket.test.ts
+++ b/src/sync/transport/websocket.test.ts
@@ -46,14 +46,18 @@ class MockWebSocket {
 }
 
 describe("createWebSocketTransport", () => {
-  let mockWs: MockWebSocket;
+  // Shared container updated by the stub constructor so tests can access the
+  // live WebSocket instance without aliasing `this` to a local variable.
+  const wsRef: { current: MockWebSocket } = {
+    current: new MockWebSocket("ws://placeholder"),
+  };
 
   beforeEach(() => {
-    mockWs = new MockWebSocket("ws://localhost:3210");
     vi.stubGlobal("WebSocket", class extends MockWebSocket {
       constructor(url: string) {
         super(url);
-        mockWs = this;
+        // Assigning to a property does not alias `this` — no-this-alias compliant.
+        wsRef.current = this as unknown as MockWebSocket;
       }
     });
   });
@@ -72,8 +76,9 @@ describe("createWebSocketTransport", () => {
   it("connects on start and reports agent as peer", async () => {
     const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
 
+    // transport.start() synchronously calls `new WebSocket(...)`, which updates wsRef.current
     const startPromise = transport.start();
-    mockWs.simulateOpen();
+    wsRef.current.simulateOpen();
     await startPromise;
 
     expect(transport.peers()).toEqual(["agent"]);
@@ -83,27 +88,27 @@ describe("createWebSocketTransport", () => {
     const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
 
     const startPromise = transport.start();
-    mockWs.simulateOpen();
+    wsRef.current.simulateOpen();
     await startPromise;
 
     const envelope = { type: "test", payload: { value: 1 } };
     transport.send("agent", envelope);
 
-    expect(mockWs.sentMessages).toHaveLength(1);
-    expect(JSON.parse(mockWs.sentMessages[0])).toEqual(envelope);
+    expect(wsRef.current.sentMessages).toHaveLength(1);
+    expect(JSON.parse(wsRef.current.sentMessages[0])).toEqual(envelope);
   });
 
   it("receives and deserializes messages", async () => {
     const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
 
     const startPromise = transport.start();
-    mockWs.simulateOpen();
+    wsRef.current.simulateOpen();
     await startPromise;
 
     const received: unknown[] = [];
     transport.onMessage((_, msg) => received.push(msg));
 
-    mockWs.simulateMessage(JSON.stringify({ type: "hello", payload: {} }));
+    wsRef.current.simulateMessage(JSON.stringify({ type: "hello", payload: {} }));
 
     expect(received).toHaveLength(1);
     expect(received[0]).toEqual({ type: "hello", payload: {} });
@@ -114,11 +119,11 @@ describe("createWebSocketTransport", () => {
     const transport = createWebSocketTransport({ url: "ws://localhost:3210" });
 
     const startPromise = transport.start();
-    mockWs.simulateOpen();
+    wsRef.current.simulateOpen();
     await startPromise;
 
     transport.onConnectionClose!(onClose);
-    mockWs.simulateClose();
+    wsRef.current.simulateClose();
 
     expect(onClose).toHaveBeenCalledWith("agent");
   });

--- a/src/sync/transport/websocket.ts
+++ b/src/sync/transport/websocket.ts
@@ -1,0 +1,126 @@
+import type {
+  SyncTransport,
+  SyncEnvelope,
+  SyncPeerId,
+} from "@vescofire/peersync";
+
+export interface WebSocketTransportOptions {
+  url: string;
+  agentPeerId?: string;
+  onConnected?: () => void;
+  onDisconnected?: () => void;
+  onError?: (error: Error) => void;
+}
+
+export function createWebSocketTransport(
+  options: WebSocketTransportOptions
+): SyncTransport {
+  const agentPeerId = options.agentPeerId ?? "agent";
+  let ws: WebSocket | null = null;
+  let localId: string | null = null;
+  const messageListeners = new Set<
+    (fromPeerId: SyncPeerId, message: SyncEnvelope) => void
+  >();
+  const openListeners = new Set<(peerId: SyncPeerId) => void>();
+  const closeListeners = new Set<(peerId: SyncPeerId) => void>();
+
+  return {
+    start: async (localPeerId?: SyncPeerId) => {
+      localId =
+        localPeerId ?? `browser-${Math.random().toString(36).substr(2, 6)}`;
+
+      return new Promise<void>((resolve, reject) => {
+        ws = new WebSocket(options.url);
+
+        ws.onopen = () => {
+          openListeners.forEach((listener) => listener(agentPeerId));
+          options.onConnected?.();
+          resolve();
+        };
+
+        ws.onerror = () => {
+          const error = new Error("WebSocket connection failed");
+          options.onError?.(error);
+          reject(error);
+        };
+
+        ws.onmessage = (event) => {
+          try {
+            const message = JSON.parse(
+              typeof event.data === "string" ? event.data : ""
+            ) as SyncEnvelope;
+            messageListeners.forEach((listener) =>
+              listener(agentPeerId, message)
+            );
+          } catch {
+            // Ignore malformed messages
+          }
+        };
+
+        ws.onclose = () => {
+          closeListeners.forEach((listener) => listener(agentPeerId));
+          options.onDisconnected?.();
+        };
+      });
+    },
+
+    stop: async () => {
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+    },
+
+    connect: async (_peerId: SyncPeerId) => {
+      // No-op: the WebSocket connection is established in start()
+    },
+
+    disconnect: (_peerId?: SyncPeerId) => {
+      if (ws) {
+        ws.close();
+        ws = null;
+      }
+    },
+
+    peers: () => {
+      return ws && ws.readyState === WebSocket.OPEN ? [agentPeerId] : [];
+    },
+
+    localPeerId: () => localId,
+
+    send: (_peerId: SyncPeerId, message: SyncEnvelope) => {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(message));
+      }
+    },
+
+    broadcast: (message: SyncEnvelope) => {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(message));
+      }
+    },
+
+    onMessage: (
+      callback: (fromPeerId: SyncPeerId, message: SyncEnvelope) => void
+    ) => {
+      messageListeners.add(callback);
+      return () => {
+        messageListeners.delete(callback);
+      };
+    },
+
+    onConnectionOpen: (callback: (peerId: SyncPeerId) => void) => {
+      openListeners.add(callback);
+      return () => {
+        openListeners.delete(callback);
+      };
+    },
+
+    onConnectionClose: (callback: (peerId: SyncPeerId) => void) => {
+      closeListeners.add(callback);
+      return () => {
+        closeListeners.delete(callback);
+      };
+    },
+  };
+}

--- a/src/sync/transport/websocket.ts
+++ b/src/sync/transport/websocket.ts
@@ -71,11 +71,11 @@ export function createWebSocketTransport(
       }
     },
 
-    connect: async (_peerId: SyncPeerId) => {
+    connect: async () => {
       // No-op: the WebSocket connection is established in start()
     },
 
-    disconnect: (_peerId?: SyncPeerId) => {
+    disconnect: () => {
       if (ws) {
         ws.close();
         ws = null;

--- a/src/sync/transport/websocket.ts
+++ b/src/sync/transport/websocket.ts
@@ -58,6 +58,7 @@ export function createWebSocketTransport(
         };
 
         ws.onclose = () => {
+          ws = null;
           closeListeners.forEach((listener) => listener(agentPeerId));
           options.onDisconnected?.();
         };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,11 @@ import tailwindcss from "@tailwindcss/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    watch: {
+      ignored: ["**/maginet-agent/**"],
+    },
+  },
   plugins: [
     tailwindcss(),
     react({


### PR DESCRIPTION
## Summary

- Add `maginet-agent/` Node.js package — an MCP server that lets Claude Code play or advise on Magic: The Gathering games on a live Maginet board
- Add browser-side WebSocket transport (`src/sync/transport/websocket.ts`) implementing the existing `SyncTransport` interface from `@vescofire/peersync`
- Add "Connect Agent" UI panel to the setup screen for one-click agent connection

### Two modes

- **Opponent mode** — Agent loads its own deck, draws cards, plays them on the board. You see its moves appear in real time.
- **Copilot mode** — Agent observes your game state (read-only) and gives advice when asked.

### 16 MCP tools

Observation: `getGameState`, `getHand`, `getBoardState`, `getDeckInfo`
Actions: `loadDeck`, `loadSnapshot`, `drawCard`, `mulligan`, `playCard`, `tapCard`, `untapAll`, `sendToHand`, `sendToDeck`, `shuffleDeck`, `addCounter`, `removeCounter`, `flipCard`, `transformCard`

### How it works

1. Claude Code spawns the MCP server (`node maginet-agent/dist/index.js --port 3210`)
2. Browser connects via WebSocket to `ws://localhost:3210`
3. Shapes sync through the existing diff/patch/snapshot channel system
4. Agent decisions come from LLM reasoning — no built-in strategy engine

## Test plan

- [ ] 32 agent-side tests passing (state, visibility, server, MCP tools, e2e integration)
- [ ] 26 browser-side tests passing (including 5 new WebSocket transport tests)
- [ ] Lint clean (0 errors, 0 warnings)
- [ ] Both packages build successfully
- [ ] Manual test: start MCP server, open Maginet, click "Connect Agent", verify connection indicator